### PR TITLE
Made repo_dir an absolute path based on the server_root_dir.

### DIFF
--- a/nbgitpuller/handlers.py
+++ b/nbgitpuller/handlers.py
@@ -56,6 +56,14 @@ class SyncHandler(IPythonHandler):
             depth = self.get_argument('depth', None)
             if depth:
                 depth = int(depth)
+            # The default working directory is the directory from which Jupyter
+            # server is launched, which is not the same as the root notebook
+            # directory assuming either --notebook-dir= is used from the
+            # command line or c.NotebookApp.notebook_dir is set in the jupyter
+            # configuration. This line assures that all repos are cloned
+            # relative to server_root_dir, so that all repos are always in
+            # scope after cloning. Sometimes server_root_dir will include
+            # things like `~` and so the path must be expanded.
             repo_dir = os.path.join(os.path.expanduser(self.settings['server_root_dir']),
                                     repo.split('/')[-1])
 

--- a/nbgitpuller/handlers.py
+++ b/nbgitpuller/handlers.py
@@ -56,7 +56,8 @@ class SyncHandler(IPythonHandler):
             depth = self.get_argument('depth', None)
             if depth:
                 depth = int(depth)
-            repo_dir = repo.split('/')[-1]
+            repo_dir = os.path.join(os.path.expanduser(self.settings['server_root_dir']),
+                                    repo.split('/')[-1])
 
             # We gonna send out event streams!
             self.set_header('content-type', 'text/event-stream')


### PR DESCRIPTION
Current behavior always clones relative to the directory that the user launches the jupyter notebook server from. This is a problem if the user either specifies `--notebook-dir=` or has `c.NotebookApp.notebook_dir` set in the config file because it may clone into a directory that is out of scope of the notebook (making the redirect fail and having unexpected clones of repos littered around the filesystem).

I've used the `server_root_dir` key in the nbapp.webapp.settings dictionary to get the server_root_dir and then clone relative to that. This guarantees that the clone is always in scope, and it provides the predictable behavior that the notebook root directory is always the directory into which things are cloned.

I have only tested this on Mac OS, and only with Jupyter Notebooks (not Jupyter Lab). I don't see any reason why it wouldn't work on other platforms or in Lab.

This will close #70.