### PR TITLE
Don't require including cloned dir name in path to open

### DIFF
--- a/docs/link.html
+++ b/docs/link.html
@@ -85,6 +85,17 @@
           </div>
         </div>
 
+        <div class="form-group row" id="filepath-container">
+          <label for="filepath" class="col-sm-2 col-form-label">File to open</label>
+          <div class="col-sm-10">
+            <input class="form-control" type="text" id="filepath" placeholder="index.ipynb"
+              oninput="displayLink()">
+            <small class="form-text text-muted">
+              This file or directory from within the repo will open when user clicks the link.
+            </small>
+          </div>
+        </div>
+
         <div class="form-group row" id="app-container">
           <div class="col-sm-2 col-form-label">
             <label for="app" class=>Application to Open</label>
@@ -119,16 +130,6 @@
           </div>
         </div>
 
-        <div class="form-group row" id="filepath-container">
-          <label for="filepath" class="col-sm-2 col-form-label">File to open</label>
-          <div class="col-sm-10">
-            <input class="form-control" type="text" id="filepath" placeholder="index.ipynb"
-              oninput="displayLink()">
-            <small class="form-text text-muted">
-              This file or directory from within the repo will open when user clicks the link.
-            </small>
-          </div>
-        </div>
     </form>
   </div>
 </body>

--- a/docs/link.js
+++ b/docs/link.js
@@ -72,7 +72,8 @@ function displayLink() {
         if (appName === 'custom') {
             var urlPath = document.getElementById('urlpath').value;
         } else {
-            var urlPath = apps[appName].generateUrlPath(filePath);
+            var repoName = new URL(repoUrl).pathname.split('/').pop().replace(/\.git$/, '');
+            var urlPath = apps[appName].generateUrlPath(repoName + '/' + filePath);
         }
 
         document.getElementById('default-link').value = generateRegularUrl(


### PR DESCRIPTION
If you had cloned github.com/yuvipanda/requirements before,
and wanted to open index.ipynb, you would have to actually
specify requirements/index.ipynb as file to open. Here,
we automatically specify the repo dir instead of requiring
users to do it
