### PR TITLE
Allow git@example.com:repo links

### DIFF
--- a/docs/link.rst
+++ b/docs/link.rst
@@ -52,8 +52,8 @@ Use the following form to create your own ``nbgitpuller`` links.
            <div class="form-group row">
              <label for="repo" class="col-sm-2 col-form-label">Git Repository URL</label>
              <div class="col-sm-6">
-               <input class="form-control" type="url" id="repo" placeholder="https://github.com/example/test"
-                 oninput="displayLink()" required pattern="(git|https?)://.+">
+               <input class="form-control" type="text" id="repo" placeholder="https://github.com/example/test"
+                 oninput="displayLink()" required pattern="((git|https?)://.+|git@.+:.+)">
                <div class="invalid-feedback">
                  Must be a valid git URL
                </div>


### PR DESCRIPTION
GitLab often generates SSH links of the form: `git@example.com:project/repo.git`. This patch allows the user to copy-paste such "URLs" without receiving a form validation error.