### PR TITLE
Fix legacy links with empty path

### DIFF
--- a/nbgitpuller/handlers.py
+++ b/nbgitpuller/handlers.py
@@ -192,9 +192,9 @@ class LegacyInteractRedirectHandler(IPythonHandler):
         repo_url = 'https://github.com/{account}/{repo}'.format(account=account, repo=repo)
         query = {
             'repo': repo_url,
+            # branch & subPath are optional
             'branch': self.get_argument('branch', 'gh-pages'),
-            'depth': self.get_argument('depth'),
-            'subPath': self.get_argument('path')
+            'subPath': self.get_argument('path', '.')
         }
         new_url = '{base}git-pull?{query}'.format(
             base=self.base_url,


### PR DESCRIPTION
empty query argument for 'path' seems to be no longer
recognized by nbgitpuller / tornado, so we explicitly make
sure we open in 'current directory'

We also don't wanna support 'depth' in legacy URLs,
so we remove support for it.