### PR TITLE
Set authorship info on each commit, rather than repo-wide

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -221,7 +221,13 @@ class GitPuller(Configurable):
 
         # Merge master into local!
         yield from self.ensure_lock()
-        yield from execute_cmd(['git', 'merge', '-Xours', 'origin/{}'.format(self.branch_name)], cwd=self.repo_dir)
+        yield from execute_cmd([
+            'git',
+            '-c', 'user.email=nbgitpuller@nbgitpuller.link',
+            '-c', 'user.name=nbgitpuller',
+            'merge', 
+            '-Xours', 'origin/{}'.format(self.branch_name)
+        ], cwd=self.repo_dir)
 
 
 

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -204,13 +204,17 @@ class GitPuller(Configurable):
         # positive, returning True even when there are no local changes (git diff-files seems to return
         # bogus output?). While ideally that would not happen, allowing empty commits keeps us
         # resilient to that issue.
-        # We explicitly set authorship of the commits we are making, to keep that separate from
-        # whatever author info is set in system / repo config by the user.
+        # We explicitly set user info of the commits we are making, to keep that separate from
+        # whatever author info is set in system / repo config by the user. We pass '-c' to git
+        # itself (rather than to 'git commit') to temporarily set config variables. This is
+        # better than passing --author, since git treats author separately from committer.
         if self.repo_is_dirty():
             yield from self.ensure_lock()
             yield from execute_cmd([
-                'git', 'commit', 
-                '--author', 'nbgitpuller <nbgitpuller@nbgitpuller.link>',
+                'git',
+                '-c', 'user.email=nbgitpuller@nbgitpuller.link',
+                '-c', 'user.name=nbgitpuller',
+                'commit', 
                 '-am', 'Automatic commit by nbgitpuller', 
                 '--allow-empty'
             ], cwd=self.repo_dir)

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -214,8 +214,8 @@ class GitPuller(Configurable):
                 'git',
                 '-c', 'user.email=nbgitpuller@nbgitpuller.link',
                 '-c', 'user.name=nbgitpuller',
-                'commit', 
-                '-am', 'Automatic commit by nbgitpuller', 
+                'commit',
+                '-am', 'Automatic commit by nbgitpuller',
                 '--allow-empty'
             ], cwd=self.repo_dir)
 
@@ -225,7 +225,7 @@ class GitPuller(Configurable):
             'git',
             '-c', 'user.email=nbgitpuller@nbgitpuller.link',
             '-c', 'user.name=nbgitpuller',
-            'merge', 
+            'merge',
             '-Xours', 'origin/{}'.format(self.branch_name)
         ], cwd=self.repo_dir)
 

--- a/tests/test_gitpuller.py
+++ b/tests/test_gitpuller.py
@@ -180,6 +180,10 @@ def test_merging_simple():
 
             puller.pull_all()
 
+            # There should be a commit made *before* the pull that has our explicit
+            # authorship, to record that it was made by nbgitpuller
+            assert puller.git('show', '-s', '--format="%an <%ae>"', 'HEAD^1') == '"nbgitpuller <nbgitpuller@nbgitpuller.link>"'
+
             assert puller.read_file('README.md') == '2'
             assert pusher.read_file('README.md') == '3'
 


### PR DESCRIPTION
Some users were running into issues where somehow the
authorship info set during initialization is lost, causing
git commit to fail with error messages about lack of authorship
information.

We explicitly pass it in now during commit, making it far
more robust. It also means we can clearly distinguish the
commits made by nbgitpuller vs manually by the user.

Finally, I had bought the nbgitpuller.link domain so it
seems a reasonable thing to use as email :)

Fixes #84