### PR TITLE
Link generator: init application type from query params

### DIFF
--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -88,11 +88,15 @@ function populateFromQueryString() {
     // preseed values if specified in the url
     var params = new URLSearchParams(window.location.search);
     // Parameters are read from query string, and <input> fields are set to them
-    var allowedParams = ['hub', 'repo', 'branch', 'app'];
+    var allowedParams = ['hub', 'repo', 'branch', 'app', 'urlpath'];
+    if (params.has("urlpath")) {
+        // setting urlpath implies a custom app
+        form.querySelector('input[name="app"]:checked').value = 'custom';
+    }
     for (var i = 0; i < allowedParams.length; i++) {
         var param = allowedParams[i];
         if (params.has(param)) {
-            if (param === 'app') {
+            if ((param === 'app') && !params.has("urlpath")) {
                 form.querySelector('input[name="app"]:checked').value = params.get(param);
             } else {
                 document.getElementById(param).value = params.get(param);

--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -88,14 +88,17 @@ function populateFromQueryString() {
     // preseed values if specified in the url
     var params = new URLSearchParams(window.location.search);
     // Parameters are read from query string, and <input> fields are set to them
-    var allowedParams = ['hub', 'repo', 'branch'];
+    var allowedParams = ['hub', 'repo', 'branch', 'app'];
     for (var i = 0; i < allowedParams.length; i++) {
         var param = allowedParams[i];
         if (params.has(param)) {
-            document.getElementById(param).value = params.get(param);
+            if (param === 'app') {
+                form.querySelector('input[name="app"]:checked').value = params.get(param);
+            } else {
+                document.getElementById(param).value = params.get(param);
+            }
         }
     }
-
 }
 
 /**

--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -91,13 +91,14 @@ function populateFromQueryString() {
     var allowedParams = ['hub', 'repo', 'branch', 'app', 'urlpath'];
     if (params.has("urlpath")) {
         // setting urlpath implies a custom app
-        form.querySelector('input[name="app"]:checked').value = 'custom';
+        document.getElementById('app-custom').checked = true;
     }
     for (var i = 0; i < allowedParams.length; i++) {
         var param = allowedParams[i];
         if (params.has(param)) {
             if ((param === 'app') && !params.has("urlpath")) {
-                form.querySelector('input[name="app"]:checked').value = params.get(param);
+                radioId = 'app-' + params.get(param).toLowerCase();
+                document.getElementById(radioId).checked = true;
             } else {
                 document.getElementById(param).value = params.get(param);
             }


### PR DESCRIPTION
This PR allows the nbgitpuller link generator to pre-populate the application type and urlpath from query parameters, just like hub, repo, and branch can be pre-populated.

```
# this should prepopulate the application choice
https://jupyterhub.github.io/nbgitpuller/link.html?hub=https://my-jupyter-hub.example.com&app=jupyterlab&repo=https://my-gitlab.example.com/<GROUP or USER>/<REPO>

# this should prepopulate application choices to custom and urlpath to something
https://jupyterhub.github.io/nbgitpuller/link.html?hub=https://my-jupyter-hub.example.com&urlpath=/custom/stuff&repo=https://my-gitlab.example.com/<GROUP or USER>/<REPO>
```