### PR TITLE
Made the checkout from the reset_deleted_files to use the origin.

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -108,7 +108,7 @@ class GitPuller(Configurable):
 
         for filename in deleted_files:
             if filename:  # Filter out empty lines
-                yield from execute_cmd(['git', 'checkout', '--', filename], cwd=self.repo_dir)
+                yield from execute_cmd(['git', 'checkout', 'origin/{}'.format(self.branch_name), '--', filename], cwd=self.repo_dir)
 
     def repo_is_dirty(self):
         """


### PR DESCRIPTION
As reported in #106, deleting files doesn't necessarily bring back a fresh copy. If you have changed a file, and then run gitpuller again, it will autocommit the changes. Then if you delete the file, the code as written, pulls in a fresh copy from the most recent commit. However, this most recent commit has the changed file, so you do not get a fresh copy from the repository. I've changed the `reset_deleted_files` to use the origin/branch when checking out the file in order to adhere to the behavior as documented by nbgitpuller.