### PR TITLE
Use shallow clones by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: python
 python:
-  - "3.6"
+  - "3.7"
 install: pip install tox-travis
 script: tox

--- a/nbgitpuller/__init__.py
+++ b/nbgitpuller/__init__.py
@@ -5,6 +5,7 @@ from notebook.utils import url_path_join
 from tornado.web import StaticFileHandler
 import os
 
+
 def _jupyter_server_extension_paths():
     return [{
         'module': 'nbgitpuller',

--- a/nbgitpuller/handlers.py
+++ b/nbgitpuller/handlers.py
@@ -2,7 +2,6 @@ from tornado import gen, web, locks
 import traceback
 import urllib.parse
 
-from notebook.utils import url_path_join
 from notebook.base.handlers import IPythonHandler
 import threading
 import json
@@ -12,6 +11,7 @@ import jinja2
 
 from .pull import GitPuller
 from .version import __version__
+
 
 class SyncHandler(IPythonHandler):
     def __init__(self, *args, **kwargs):
@@ -74,6 +74,7 @@ class SyncHandler(IPythonHandler):
             gp = GitPuller(repo, branch, repo_dir, depth=depth, parent=self.settings['nbapp'])
 
             q = Queue()
+
             def pull():
                 try:
                     for line in gp.pull():
@@ -100,8 +101,8 @@ class SyncHandler(IPythonHandler):
                         'phase': 'error',
                         'message': str(progress),
                         'output': '\n'.join([
-                            l.strip()
-                            for l in traceback.format_exception(
+                            line.strip()
+                            for line in traceback.format_exception(
                                 type(progress), progress, progress.__traceback__
                             )
                         ])
@@ -116,14 +117,15 @@ class SyncHandler(IPythonHandler):
                 'phase': 'error',
                 'message': str(e),
                 'output': '\n'.join([
-                    l.strip()
-                    for l in traceback.format_exception(
+                    line.strip()
+                    for line in traceback.format_exception(
                         type(e), e, e.__traceback__
                     )
                 ])
             })
         finally:
             self.git_lock.release()
+
 
 class UIHandler(IPythonHandler):
     def initialize(self):
@@ -182,6 +184,7 @@ class LegacyGitSyncRedirectHandler(IPythonHandler):
             query=self.request.query
         )
         self.redirect(new_url)
+
 
 class LegacyInteractRedirectHandler(IPythonHandler):
     @web.authenticated

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -56,13 +56,6 @@ class GitPuller(Configurable):
         environment variable."""
     )
 
-    @default('depth')
-    def _depth_default(self):
-        depth = os.environ.get('NBGITPULLER_DEPTH')
-        if depth:
-            return int(depth)
-        return 1
-
     def __init__(self, git_url, branch_name, repo_dir, **kwargs):
         assert git_url and branch_name
 

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -43,12 +43,12 @@ def execute_cmd(cmd, **kwargs):
             raise subprocess.CalledProcessError(ret, cmd)
 
 class GitPuller(Configurable):
-    depth = Integer(None, allow_none=True, config=True,
+    depth = Integer(1, config=True,
                     help="""
                     Depth (ie, commit count) to which to perform a
                     shallow git clone.
 
-                    If not set, disables shallow clones.
+                    If not set, clones to depth 1.
 
                     Defaults to reading from the NBGITPULLER_DEPTH
                     environment variable.

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -4,7 +4,7 @@ import logging
 import time
 import argparse
 import datetime
-from traitlets import Integer
+from traitlets import Integer, default
 from traitlets.config import Configurable
 from functools import partial
 
@@ -47,7 +47,6 @@ def execute_cmd(cmd, **kwargs):
 
 class GitPuller(Configurable):
     depth = Integer(
-        int(os.environ.get('NBGITPULLER_DEPTH', 1)),
         config=True,
         help="""
         Depth (ie, commit count) to which to perform a
@@ -58,6 +57,15 @@ class GitPuller(Configurable):
         Defaults to reading from the NBGITPULLER_DEPTH
         environment variable."""
     )
+
+    @default('depth')
+    def _depth_default(self):
+        """This is a workaround for setting the same default directly in the
+        definition of the traitlet above. Without it, the test fails because a
+        change in the environment variable has no impact. I think this is a
+        consequence of the tests not starting with a totally clean environment
+        where the GitPuller class hadn't been loaded already."""
+        return int(os.environ.get('NBGITPULLER_DEPTH', 1))
 
     def __init__(self, git_url, branch_name, repo_dir, **kwargs):
         assert git_url and branch_name

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -4,9 +4,10 @@ import logging
 import time
 import argparse
 import datetime
-from traitlets import Integer, default
+from traitlets import Integer
 from traitlets.config import Configurable
 from functools import partial
+
 
 def execute_cmd(cmd, **kwargs):
     """
@@ -23,6 +24,7 @@ def execute_cmd(cmd, **kwargs):
     # This should behave the same as .readline(), but splits on `\r` OR `\n`,
     # not just `\n`.
     buf = []
+
     def flush():
         line = b''.join(buf).decode('utf8', 'replace')
         buf[:] = []
@@ -41,6 +43,7 @@ def execute_cmd(cmd, **kwargs):
         ret = proc.wait()
         if ret != 0:
             raise subprocess.CalledProcessError(ret, cmd)
+
 
 class GitPuller(Configurable):
     depth = Integer(
@@ -87,7 +90,6 @@ class GitPuller(Configurable):
         clone_args.extend([self.git_url, self.repo_dir])
         yield from execute_cmd(clone_args)
         logging.info('Repo {} initialized'.format(self.repo_dir))
-
 
     def reset_deleted_files(self):
         """
@@ -177,7 +179,6 @@ class GitPuller(Configurable):
                 os.rename(f, new_file_name)
                 yield 'Renamed {} to {} to avoid conflict with upstream'.format(f, new_file_name)
 
-
     def update(self):
         """
         Do the pulling if necessary
@@ -223,7 +224,6 @@ class GitPuller(Configurable):
             'merge',
             '-Xours', 'origin/{}'.format(self.branch_name)
         ], cwd=self.repo_dir)
-
 
 
 def main():

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -49,13 +49,12 @@ class GitPuller(Configurable):
     depth = Integer(
         config=True,
         help="""
-        Depth (ie, commit count) to which to perform a
-        shallow git clone.
+        Depth (ie, commit count) of clone operations. Set this to 0 to make a
+        full depth clone.
 
-        If not set, clones to depth 1.
-
-        Defaults to reading from the NBGITPULLER_DEPTH
-        environment variable."""
+        Defaults to the value of the environment variable NBGITPULLER_DEPTH, or
+        1 if the the environment variable isn't set.
+        """
     )
 
     @default('depth')

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -43,23 +43,25 @@ def execute_cmd(cmd, **kwargs):
             raise subprocess.CalledProcessError(ret, cmd)
 
 class GitPuller(Configurable):
-    depth = Integer(1, config=True,
-                    help="""
-                    Depth (ie, commit count) to which to perform a
-                    shallow git clone.
+    depth = Integer(
+        int(os.environ.get('NBGITPULLER_DEPTH', 1)),
+        config=True,
+        help="""
+        Depth (ie, commit count) to which to perform a
+        shallow git clone.
 
-                    If not set, clones to depth 1.
+        If not set, clones to depth 1.
 
-                    Defaults to reading from the NBGITPULLER_DEPTH
-                    environment variable.
-                    """)
+        Defaults to reading from the NBGITPULLER_DEPTH
+        environment variable."""
+    )
 
     @default('depth')
     def _depth_default(self):
         depth = os.environ.get('NBGITPULLER_DEPTH')
         if depth:
             return int(depth)
-        return None
+        return 1
 
     def __init__(self, git_url, branch_name, repo_dir, **kwargs):
         assert git_url and branch_name

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36, flake8
+envlist=py37, flake8
 
 [testenv]
 commands=
@@ -12,11 +12,11 @@ deps=
     notebook
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3.7
 deps =
     flake8
     six
     tornado
     notebook
 commands =
-    flake8 gitautosync tests --max-line-length=150
+    flake8 nbgitpuller tests --exclude nbgitpuller/__init__.py --max-line-length=150


### PR DESCRIPTION
Deep clones take up so much unnecessary space, and are unused
99% of the time. Shallow cloning in git is pretty good these
days. This doesn't touch pre-existing clones