### PR TITLE
Fix file paths or application paths

### DIFF
--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -134,12 +134,10 @@ function displayLink() {
             var userName = new URL(repoUrl).pathname.split('/')[1];
             var urlPath;
             if (activeTab === "tab-auth-binder") {
-                if (contentRepoUrl.disabled) {
-                    urlPath = apps[appName].generateUrlPath(repoName + '/' + filePath);
-                } else {
-                    var contentRepoName = new URL(contentRepoUrl).pathname.split('/').pop().replace(/\.git$/, '');
-                    urlPath = apps[appName].generateUrlPath(contentRepoName + '/' + filePath);
-                }
+                var contentRepoName = new URL(contentRepoUrl).pathname.split('/').pop().replace(/\.git$/, '');
+                urlPath = apps[appName].generateUrlPath(contentRepoName + '/' + filePath);
+            } else {
+                urlPath = apps[appName].generateUrlPath(repoName + '/' + filePath);
             }
         }
 


### PR DESCRIPTION
Fixes https://github.com/jupyterhub/nbgitpuller/issues/139

Before `activeTab` we were using `contentRepo` to determine if the Binder tab was active. Removing the extra `contentRepo` check should fix the app link generation.