### PR TITLE
Compare current branch to target - don't assume already on target branch locally

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -132,7 +132,7 @@ class GitPuller(Configurable):
         Return list of files that have been changed upstream belonging to a particular kind of change
         """
         output = subprocess.check_output([
-            'git', 'log', '{}..origin/{}'.format(self.branch_name, self.branch_name),
+            'git', 'log', '..origin/{}'.format(self.branch_name),
             '--oneline', '--name-status'
         ], cwd=self.repo_dir).decode()
         files = []


### PR DESCRIPTION
Otherwise switching branches doesn't work as per issue #124 

This just uses the git syntax:

git log ..origin/branchname

instead of the old

git log branchname..origin/branchname

In the old case, this failed when the local repo wasn't already on branchname:

fatal: ambiguous argument 'branchname..origin/branchname': unknown revision or path not in the working tree.