### PR TITLE
Make the environment repo branch required for binder

### DIFF
--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -88,6 +88,7 @@ function changeTab(div) {
     var hub = document.getElementById("hub");
     var hub_help_text = document.getElementById("hub-help-text");
     var env_repo = document.getElementById("repo");
+    var env_repo_branch = document.getElementById("branch");
     var env_repo_help_text = document.getElementById("env-repo-help-text");
     var content_repo = document.getElementById("content-repo-group");
     var content_branch = document.getElementById("content-branch-group");
@@ -100,6 +101,8 @@ function changeTab(div) {
         hub.labels[0].innerHTML = "BinderHub URL";
         env_repo.labels[0].innerHTML = "Git Environment Repository URL";
         env_repo_help_text.hidden = false;
+        env_repo_branch.required = true;
+        env_repo_branch.pattern = ".+";
         content_repo.hidden = false;
         content_branch.hidden = false;
     } else {
@@ -108,6 +111,7 @@ function changeTab(div) {
         hub.labels[0].innerHTML = "JupyterHub URL";
         env_repo.labels[0].innerHTML = "Git Repository URL";
         env_repo_help_text.hidden = true;
+        env_repo_branch.required = false;
         content_repo.hidden = true;
         content_branch.hidden = true;
     }

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -75,7 +75,7 @@ Use the following form to create your own ``nbgitpuller`` links.
                  <div class="input-group-prepend">
                    <span class="input-group-text" id="branch-prepend-label">branch</span>
                  </div>
-                 <input name="branch" id="branch" type="text" class="form-control" placeholder="master" aria-label="Branch Name" aria-describedby="branch-prepend-label">
+                 <input name="branch" id="branch" type="text" class="form-control" value="master" aria-label="Branch Name" aria-describedby="branch-prepend-label">
                  <div class="invalid-feedback">
                     Must specify a branch name
                  </div>

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -76,6 +76,9 @@ Use the following form to create your own ``nbgitpuller`` links.
                    <span class="input-group-text" id="branch-prepend-label">branch</span>
                  </div>
                  <input name="branch" id="branch" type="text" class="form-control" placeholder="master" aria-label="Branch Name" aria-describedby="branch-prepend-label">
+                 <div class="invalid-feedback">
+                    Must specify a branch name
+                 </div>
                </div>
              </div>
            </div>

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -97,7 +97,7 @@ Use the following form to create your own ``nbgitpuller`` links.
                  <div class="input-group-prepend">
                    <span class="input-group-text" id="content-branch-prepend-label">branch</span>
                  </div>
-                 <input name="content-branch" id="content-branch" type="text" class="form-control" placeholder="master" aria-label="Branch Name" aria-describedby="content-branch-prepend-label">
+                 <input name="content-branch" id="content-branch" type="text" class="form-control" value="master" aria-label="Branch Name" aria-describedby="content-branch-prepend-label">
                </div>
              </div>
             </div>


### PR DESCRIPTION
If no branch is specified for the environment repo, Binder throws a 400 error:
![bad-request](https://user-images.githubusercontent.com/7579677/87661699-bb888000-c769-11ea-8eea-56214eb0dcab.png)

As @fomightez reported [here](https://github.com/jupyterhub/nbgitpuller/issues/96#issuecomment-658197350), the green check mark next to the env repo branch input is misleading and may imply that the placeholder is used or no branch is required.
![misleading check mark](https://user-images.githubusercontent.com/7579677/87662219-8af51600-c76a-11ea-921d-e50003b8e125.png)

This PR makes the env repo branch a required field.
![required](https://user-images.githubusercontent.com/7579677/87662348-bd067800-c76a-11ea-80fd-8981a6ae5b9e.png)

Thanks @fomightez for reporting this :rocket: 