### PR TITLE
Travis pypi deployment, README fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,20 @@ sudo: false
 language: python
 python:
   - "3.6"
-install: pip install tox-travis
-script: tox
 
-deploy:
-  - provider: pypi
-    user: __token__
-    # password: see secret PYPI_PASSWORD variable
-    distributions: sdist bdist_wheel
-    on:
-      tags: true
+jobs:
+  include:
+    - name: test
+      install: pip install tox-travis
+      script: tox
+    - name: deploy
+      if: tag IS present
+      script: skip
+      skip_cleanup: true
+      deploy:
+        provider: pypi
+        user: __token__
+        # password: see secret PYPI_PASSWORD variable
+        distributions: sdist bdist_wheel
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ python:
   - "3.6"
 install: pip install tox-travis
 script: tox
+
+deploy:
+  - provider: pypi
+    user: __token__
+    # password: see secret PYPI_PASSWORD variable
+    distributions: sdist bdist_wheel
+    on:
+      tags: true

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,7 @@ nbgitpuller
 ===========
 
 ``nbgitpuller`` lets you distribute content in a git repository to your
-students by having them click a simple link. :ref:`Automatic, opinioned
-conflict resolution <topic/automatic-merging>` ensures that your students are
+students by having them click a simple link. `Automatic merging <https://jupyterhub.github.io/nbgitpuller/topic/automatic-merging.html>`_ ensures that your students are
 never exposed to ``git`` directly. It is primarily used with a JupyterHub,
 but can also work on students' local computers.
 

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ students by having them click a simple link. `Automatic merging <https://jupyter
 never exposed to ``git`` directly. It is primarily used with a JupyterHub,
 but can also work on students' local computers.
 
-.. image:: docs/_static/nbpuller.gif
+.. image:: https://raw.githubusercontent.com/jupyterhub/nbgitpuller/v0.8.0/docs/_static/nbpuller.gif
 
 For a lot more information, see the `documentation
 <https://jupyterhub.github.io/nbgitpuller>`_

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,67 @@
+# How to make a release
+
+`nbgitpuller` is a package available on
+[PyPI](https://pypi.org/project/nbgitpuller/) and
+[conda-forge](https://anaconda.org/conda-forge/nbgitpuller).
+These are instructions on how to make a release on PyPI.
+The PyPI release is done automatically by TravisCI when a tag is pushed.
+
+
+## Steps to make a release
+
+1. Checkout master and make sure it is up to date.
+
+   ```shell
+   ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
+   git checkout master
+   git fetch $ORIGIN master
+   git reset --hard $ORIGIN/master
+   # WARNING! This next command deletes any untracked files in the repo
+   git clean -xfd
+   ```
+
+1. Set the `__version__` variable in
+   [`nbgitpuller/version.py`](nbgitpuller/version.py)
+   and make a commit.
+
+   ```
+   git add nbgitpuller/version.py
+   VERSION=...  # e.g. 1.2.3
+   git commit -m "release $VERSION"
+   ```
+
+1. Reset the `__version__` variable in
+   [`nbgitpuller/version.py`](nbgitpuller/version.py)
+   to an incremented patch version with a `dev` element, then make a commit.
+   ```
+   git add nbgitpuller/version.py
+   git commit -m "back to dev"
+   ```
+
+1. Push your two commits to master.
+
+   ```shell
+   # first push commits without a tags to ensure the
+   # commits comes through, because a tag can otherwise
+   # be pushed all alone without company of rejected
+   # commits, and we want have our tagged release coupled
+   # with a specific commit in master
+   git push $ORIGIN master
+   ```
+
+1. Create a git tag for the pushed release commit and push it.
+
+   ```shell
+   git tag -a $VERSION -m $VERSION HEAD~1
+
+   # then verify you tagged the right commit
+   git log
+
+   # then push it
+   git push $ORIGIN refs/tags/$VERSION
+   ```
+
+1. Following the release to PyPI, an automated PR should arrive to
+   [conda-forge/nbgitpuller-feedstock](https://github.com/conda-forge/nbgitpuller-feedstock),
+   check for the tests to succeed on this PR and then merge it to successfully
+   update the package for `conda` on the `conda-forge` channel.

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ setup(
     author='Peter Veerman, YuviPanda',
     author_email='peterkangveerman@gmail.com',
     description='Notebook Extension to do one-way synchronization of git repositories',
+    long_description=open('README.rst').read(),
+    long_description_content_type='text/x-rst',
     packages=find_packages(),
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
This should automate the deployment of releases to Pypi when the repo is tagged. RELEASE.md is copied from https://github.com/jupyterhub/oauthenticator @consideRatio 
Also fixes the README link to the docs, and adds it to the pypi long description.

This requires a secret token to be added to Travis