### PR TITLE
CI: ensure tox run's flake8 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 jobs:
   include:
     - name: test
-      install: pip install tox-travis
+      install: pip install tox
       script: tox
     - name: deploy
       if: tag IS present

--- a/tox.ini
+++ b/tox.ini
@@ -19,4 +19,4 @@ deps =
     tornado
     notebook
 commands =
-    flake8 nbgitpuller tests --exclude nbgitpuller/__init__.py --max-line-length=150
+    flake8 nbgitpuller tests --exclude nbgitpuller/__init__.py --ignore E127 --max-line-length=150


### PR DESCRIPTION
Apparently the tox-travis package did something, but it caused a
discrepancy between the local development experience and didn't run both
environments. So I'm removing it in favor of something simpler that
doesn't require additional understanding about tox-travis.