### PR TITLE
CI: stop triggering CircleCI on automated pushes to gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           name: Pushing documentation to gh-pages
           command: |
             pip install --user ghp-import
-            ghp-import -n -p docs/_build/html
+            ghp-import --no-jekyll --push --message "Update documentation [skip ci]" docs/_build/html
 
 workflows:
   version: 2


### PR DESCRIPTION
I noticed how there were failing builds in CircleCI. They were triggered by pushes to gh-pages, and complained that there were no .circleci/config.yml in there (in the gh-pages branch).

When I was trying to create a stub it required me to define a lot to not fail validation. So, instead I opt to disable the build by adding a "[skip ci]" within the commit message for the gh-pages branch made by the `ghp-import` CLI.
