### PR TITLE
Use raw output of git ls-files to avoid quoting unicode

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -107,8 +107,8 @@ class GitPuller(Configurable):
 
         yield from self.ensure_lock()
         deleted_files = subprocess.check_output([
-            'git', 'ls-files', '--deleted'
-        ], cwd=self.repo_dir).decode().strip().split('\n')
+            'git', 'ls-files', '--deleted', '-z'
+        ], cwd=self.repo_dir).decode().strip().split('\0')
 
         for filename in deleted_files:
             if filename:  # Filter out empty lines

--- a/tests/test_gitpuller.py
+++ b/tests/test_gitpuller.py
@@ -227,14 +227,17 @@ def test_reset_file():
     """
     with Remote() as remote, Pusher(remote) as pusher:
         pusher.push_file('README.md', '1')
+        pusher.push_file('unicode🙂.txt', '2')
 
         with Puller(remote) as puller:
             os.remove(os.path.join(puller.path, 'README.md'))
+            os.remove(os.path.join(puller.path, 'unicode🙂.txt'))
 
             puller.pull_all()
 
             assert puller.git('rev-parse', 'HEAD') == pusher.git('rev-parse', 'HEAD')
             assert puller.read_file('README.md') == pusher.read_file('README.md') == '1'
+            assert puller.read_file('unicode🙂.txt') == pusher.read_file('unicode🙂.txt') == '2'
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Closes https://github.com/jupyterhub/nbgitpuller/issues/121

`git ls-files` defaults to using octal escapes for non-ascii characters. Passing `-z` disables this.