### PR TITLE
Handle lack of trailing slashes in hub URLs

### DIFF
--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -14,6 +14,9 @@ function generateRegularUrl(hubUrl, urlPath, repoUrl, branch) {
         url.searchParams.set('branch', branch);
     }
 
+    if (!url.pathname.endsWith('/')) {
+        url.pathname += '/'
+    }
     url.pathname += 'hub/user-redirect/git-pull';
 
     return url.toString();


### PR DESCRIPTION
Without this, if your hub url was something like
https://myhub.com/jupyter, your nbgitpuller URL will
be something like https://myhub.com/jupyterhub/user-redirect...
instead of https://myhub.com/jupyter/hub/user-redirect...