### PR TITLE
Branch field no longer suggests default

### DIFF
--- a/link.html
+++ b/link.html
@@ -240,15 +240,12 @@
               <div class="input-group-prepend">
                 <span class="input-group-text" id="branch-prepend-label">branch</span>
               </div>
-              <input name="branch" id="branch" type="text" class="form-control" value="master" aria-label="Branch Name" aria-describedby="branch-prepend-label">
-              <small class="form-text text-muted">
-                 Use <code>main</code> instead of <code>master</code> for
+              <input name="branch" id="branch" type="text" aria-label="Branch Name" aria-describedby="branch-prepend-label">
+              <small id="default-repo-message" class="form-text text-muted">
+                 If left blank, the default branch of your repository is used. Also note, Github now names the default branch <code>main</code> instead of <code>master</code> on
                  <a href="https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/">
                  new GitHub repositories</a>
               </small>
-              <div class="invalid-feedback">
-                 Must specify a branch name
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
The placeholder that indicated a default branch name is removed from the
branch field and the message instructing the user as to how the branch
name is handled is updated