### PR TITLE
Added branch name back to command-line usage

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -303,11 +303,13 @@ def main():
 
     parser = argparse.ArgumentParser(description='Synchronizes a github repository with a local repository.')
     parser.add_argument('git_url', help='Url of the repo to sync')
+    parser.add_argument('branch_name', default='master', help='Branch of repo to sync', nargs='?')
     parser.add_argument('repo_dir', default='.', help='Path to clone repo under', nargs='?')
     args = parser.parse_args()
 
     for line in GitPuller(
         args.git_url,
-        args.repo_dir
+        args.repo_dir,
+        branch=args.branch_name
     ).pull():
         print(line)

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -310,6 +310,10 @@ def main():
     for line in GitPuller(
         args.git_url,
         args.repo_dir,
-        branch=args.branch_name
+        branch=args.branch_name if args.branch_name else None
     ).pull():
         print(line)
+
+
+if __name__ == '__main__':
+    main()

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -303,7 +303,7 @@ def main():
 
     parser = argparse.ArgumentParser(description='Synchronizes a github repository with a local repository.')
     parser.add_argument('git_url', help='Url of the repo to sync')
-    parser.add_argument('branch_name', default='master', help='Branch of repo to sync', nargs='?')
+    parser.add_argument('branch_name', default=None, help='Branch of repo to sync', nargs='?')
     parser.add_argument('repo_dir', default='.', help='Path to clone repo under', nargs='?')
     args = parser.parse_args()
 

--- a/tests/test_gitpuller.py
+++ b/tests/test_gitpuller.py
@@ -96,6 +96,49 @@ def test_initialize():
             assert puller.git('rev-parse', 'HEAD') == pusher.git('rev-parse', 'HEAD')
 
 
+def command_line_test_helper(remote_path, branch, pusher_path):
+    work_dir = "/".join(os.path.dirname(os.path.abspath(__file__)).split("/")[:-1]) + "/nbgitpuller"
+    try:
+        cmd = ['python3', 'pull.py', remote_path, branch, pusher_path]
+        sp.check_output(
+            cmd,
+            cwd=work_dir
+        ).decode()
+        return True
+    except Exception:
+        return False
+
+
+def test_command_line_existing_branch():
+    branch = "master"
+    with Remote() as remote, Pusher(remote) as pusher:
+        pusher.push_file('README.md', '1')
+        remotepath = "file://%s" % os.path.abspath(remote.path)
+        pusherpath = os.path.abspath(pusher.path)
+        subprocess_result = command_line_test_helper(remotepath, branch, pusherpath)
+    assert subprocess_result
+
+
+def test_command_line_default_branch():
+    branch = ""
+    with Remote() as remote, Pusher(remote) as pusher:
+        pusher.push_file('README.md', '1')
+        remotepath = "file://%s" % os.path.abspath(remote.path)
+        pusherpath = os.path.abspath(pusher.path)
+        subprocess_result = command_line_test_helper(remotepath, branch, pusherpath)
+    assert subprocess_result
+
+
+def test_command_line_non_existing_branch():
+    branch = "wrong"
+    with Remote() as remote, Pusher(remote) as pusher:
+        pusher.push_file('README.md', '1')
+        remotepath = "file://%s" % os.path.abspath(remote.path)
+        pusherpath = os.path.abspath(pusher.path)
+        subprocess_result = command_line_test_helper(remotepath, branch, pusherpath)
+    assert not subprocess_result
+
+
 def test_branch_exists():
     with Remote() as remote, Pusher(remote) as pusher:
         pusher.push_file('README.md', '1')


### PR DESCRIPTION
I inadvertently removed the command-line usage of the tool.

This works now:
gitpuller [-h] git_url [branch_name] [repo_dir]

Resolves Issue: #184 