### PR TITLE
Rename nbgitpuller repo's master branch to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ workflows:
       - build_docs
       - push_docs:
           filters:  # using regex filters requires the entire branch to match
-              branches:
-                only:  # only branches matching the below regex filters will run
-                  - master
+            branches:
+              only:  # only branches matching the below regex filters will run
+                - main
 
 commands:
   build_site:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,13 +9,13 @@ The PyPI release is done automatically by TravisCI when a tag is pushed.
 
 ## Steps to make a release
 
-1. Checkout master and make sure it is up to date.
+1. Checkout main and make sure it is up to date.
 
    ```shell
    ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
-   git checkout master
-   git fetch $ORIGIN master
-   git reset --hard $ORIGIN/master
+   git checkout main
+   git fetch $ORIGIN main
+   git reset --hard $ORIGIN/main
    # WARNING! This next command deletes any untracked files in the repo
    git clean -xfd
    ```
@@ -38,15 +38,15 @@ The PyPI release is done automatically by TravisCI when a tag is pushed.
    git commit -m "back to dev"
    ```
 
-1. Push your two commits to master.
+1. Push your two commits to main.
 
    ```shell
    # first push commits without a tags to ensure the
    # commits comes through, because a tag can otherwise
    # be pushed all alone without company of rejected
    # commits, and we want have our tagged release coupled
-   # with a specific commit in master
-   git push $ORIGIN master
+   # with a specific commit in main
+   git push $ORIGIN main
    ```
 
 1. Create a git tag for the pushed release commit and push it.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,8 +32,8 @@ templates_path = ["_templates"]
 source_suffix = [".rst", ".md"]
 
 
-# The master toctree document.
-master_doc = "index"
+# The root toctree document.
+root_doc = master_doc = "index"
 
 # General information about the project.
 project = "nbgitpuller"
@@ -85,7 +85,7 @@ html_theme = "sphinx_book_theme"
 html_context = {
     "github_user": "jupyterhub",
     "github_repo": "nbgitpuller",
-    "github_version": "master",
+    "github_version": "main",
     "doc_path": "doc",
     "source_suffix": source_suffix,
 }
@@ -130,7 +130,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (
-        master_doc,
+        root_doc,
         "nbgitpuller.tex",
         "nbgitpuller Documentation",
         "The nbgitpuller Team",
@@ -143,7 +143,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "nbgitpuller", "nbgitpuller Documentation", [author], 1)]
+man_pages = [(root_doc, "nbgitpuller", "nbgitpuller Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -153,7 +153,7 @@ man_pages = [(master_doc, "nbgitpuller", "nbgitpuller Documentation", [author], 
 #  dir menu entry, description, category)
 texinfo_documents = [
     (
-        master_doc,
+        root_doc,
         "nbgitpuller",
         "nbgitpuller Documentation",
         author,


### PR DESCRIPTION
Part of work in https://github.com/jupyterhub/team-compass/issues/412 to rename our repo's master branches to main.

Actions to take, in order:

- [x] approve this PR
- [x] rename the `master` branch to `main` in GitHub (this should automatically update all PRs)
- [x] merge this PR
- [ ] check the publish workflow publishes the expected outputs if relevant
- [ ] If readthedocs.org is used, set main as the default branch explicitly: admin -> advanced -> default branch

```
$ git grep master

CHANGELOG.md:- UI: Branch input placeholder no longer suggests master branch [#180](https://github.com/jupyterhub/nbgitpuller/pull/180) ([@sean-morris](https://github.com/sean-morris))
CHANGELOG.md:- Tell users about `main` vs `master` branches [#170](https://github.com/jupyterhub/nbgitpuller/pull/170) ([@yuvipanda](https://github.com/yuvipanda))

Comment: Changelog is fine!



binder/link_generator.ipynb:    "- **Default Values**: to avoid having to enter the same values in the widget's text fields on a repetitive basis, add the string values to the function's parameters. For example, the `branch` parameter defaults to `master`."
binder/link_generator.ipynb:      "text/plain": "'https://my.hub.com/hub/lti/launch?next=%2Fuser-redirect%2Fgit-pull?repo%3D%26branch%3Dmaster%26urlpath%3Dlab%252Ftree%252F.%252F%253Fautodecode'"
binder/link_generator.ipynb:    "def make_launch_link(is_assignment_link=True, is_jupyterlab=True, is_lti11=True, branch='master', hub_url='https://my.hub.com', repo_url='', urlpath=''):\n",

Comment: If the link generator references the master branch or not is irrelevant to the nbgitpuller project's use of a main or master branch I think.



docs/conf.py:github_doc_root = "https://github.com/rtfd/recommonmark/tree/master/doc/"

Comment: Just a link.



docs/conf.py:root_doc = master_doc = "index"

Comment: root_doc is now an option to master_doc supported by a modern version of sphinx, so setting both is a compatibility strategy.



docs/contributing.md:for it as well. A mix of [reStructuredText](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html)

Comment: Just a link.



docs/link.rst:                 <input name="branch" id="branch" type="text" class="form-control" value="master" aria-label="Branch Name" aria-describedby="branch-prepend-label">
docs/link.rst:                    Use <code>main</code> instead of <code>master</code> for
docs/link.rst:                 <input name="content-branch" id="content-branch" type="text" class="form-control" value="master" aria-label="Branch Name" aria-describedby="content-branch-prepend-label">

Comment: these make sense.



docs/topic/repo-best-practices.md:gitignore](https://github.com/github/gitignore/blob/master/Python.gitignore)

Comment: Just a link.



docs/topic/url-options.rst:Branch in the git repo to pull from. Defaults to ``master``.

Comment: correct documentation.



nbgitpuller/pull.py:        # Merge master into local!
tests/test_api.py:            'branch': 'master',
tests/test_api.py:        assert '--branch master' in s
tests/test_api.py:            'branch': 'master',
tests/test_api.py:            'branch': 'master',
tests/test_gitpuller.py:        self.git('push', 'origin', 'master')
tests/test_gitpuller.py:    def __init__(self, remote, path='puller', branch="master", *args, **kwargs):
tests/test_gitpuller.py:            assert puller.git('name-rev', '--name-only', 'HEAD') == 'master'
tests/test_gitpuller.py:    branch = "master"
tests/test_gitpuller.py:            assert puller.gp.branch_exists("master")
tests/test_gitpuller.py:            assert puller.gp.resolve_default_branch() == "master"
tests/test_gitpuller.py:            pusher.git('push', 'origin', 'master')
tests/test_gitpuller.py:            pusher.git('push', 'origin', 'master')
tests/test_gitpuller.py:            pusher.git('push', '--force', 'origin', '%s:master' % orig_head)

Comment: nbgitpuller acts against master rather than main by default still, this PR only changes nbgitpuller's own code base location, so the entries above is okay.
```