### PR TITLE
[WIP] Try minimizing bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,14 @@
   "name": "nbgitpuller",
   "version": "0.10.1",
   "description": "`nbgitpuller`",
-  "devDependencies": {
+  "dependencies": {
+    "css-loader": "^6.2.0",
     "jquery": "^3.6.0",
     "webpack": "^5.45.1",
     "webpack-cli": "^4.7.2",
     "xterm": "^4.13.0",
     "xterm-addon-fit": "^0.5.0",
-    "css-loader": "^6.2.0",
-    "style-loader": "^3.2.1"
+    "mini-css-extract-plugin": "^2.2.0"
   },
   "scripts": {
     "webpack": "webpack",
@@ -24,5 +24,8 @@
   "bugs": {
     "url": "https://github.com/jupyterhub/nbgitpuller/issues"
   },
-  "homepage": "https://github.com/jupyterhub/nbgitpuller#readme"
+  "homepage": "https://github.com/jupyterhub/nbgitpuller#readme",
+  "devDependencies": {
+    "css-minimizer-webpack-plugin": "^3.0.2"
+  }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,26 +1,42 @@
 const webpack = require('webpack');
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+
+var mode = process.env.NODE_ENV || 'development';
 
 module.exports = {
     context: __dirname + "/nbgitpuller/static/",
     entry: "./js/index.js",
     output: {
         path: __dirname + "/nbgitpuller/static/dist/",
-        filename: "bundle.js",
+        filename: "[name].js",
         publicPath: '/static/dist/'
     },
     module: {
         rules: [
             {
                 test: /\.css$/i,
-                use: ['style-loader', 'css-loader']
+                use: [MiniCssExtractPlugin.loader, 'css-loader']
             },
         ]
     },
-    devtool: 'source-map',
+    devtool: (mode === 'development') ? 'inline-source-map' : false,
+    mode: mode,
+    optimization: {
+        minimize: true,
+        minimizer: [
+            `...`,
+            new CssMinimizerPlugin(),
+        ],
+    },
     plugins: [
         new webpack.ProvidePlugin({
             $: 'jquery',
             jQuery: 'jquery',
+        }),
+        new MiniCssExtractPlugin({
+            filename: "[name].css",
+            chunkFilename: "[id].css",
         }),
     ]
 }


### PR DESCRIPTION
This does a couple of things in order to optimize size for production:

- uses an env var [NODE_ENV](https://webpack.js.org/guides/production/#specify-the-mode) that when set to 'production' should"
  - tell other libraries that this is a production build and use their "optimized" version (at least that's what I understood from the docs)
  - disables source-maps (though [webpack recommends](https://webpack.js.org/guides/production/#source-mapping) these in production also, I've seen many suggestions also to remove these in prod for the sake of size)
- uses [`CssMinimizerPlugin`](https://webpack.js.org/plugins/css-minimizer-webpack-plugin/) to minify the css file we import from xterm
- uses the `...` syntax to extend existing minimizers (i.e. `terser-webpack-plugin`), according to the docs

### However
The size is only down to `401 KiB` :(  

Fixes https://github.com/jupyterhub/nbgitpuller/issues/199 (once it's done)