### PR TITLE
Slim package.json to avoid fields relevant to npm publication

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@ The PyPI release is done automatically by TravisCI when a tag is pushed.
    [`nbgitpuller/version.py`](nbgitpuller/version.py)
    and make a commit.
 
-   ```
+   ```shell
    git add nbgitpuller/version.py
    VERSION=...  # e.g. 1.2.3
    git commit -m "release $VERSION"
@@ -33,7 +33,8 @@ The PyPI release is done automatically by TravisCI when a tag is pushed.
 1. Reset the `__version__` variable in
    [`nbgitpuller/version.py`](nbgitpuller/version.py)
    to an incremented patch version with a `dev` element, then make a commit.
-   ```
+
+   ```shell
    git add nbgitpuller/version.py
    git commit -m "back to dev"
    ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
-  "name": "nbgitpuller",
-  "version": "0.10.1",
-  "description": "`nbgitpuller`",
+  "description": "Dependencies to build nbgitpuller/static/dist/bundle.js from nbgitpuller/static/js/index.js with webpack.",
   "devDependencies": {
     "jquery": "^3.6.0",
     "webpack": "^5.45.1",
@@ -14,15 +12,5 @@
   "scripts": {
     "webpack": "webpack",
     "webpack:watch": "webpack --watch"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/jupyterhub/nbgitpuller.git"
-  },
-  "author": "",
-  "license": "BSD-3-Clause",
-  "bugs": {
-    "url": "https://github.com/jupyterhub/nbgitpuller/issues"
-  },
-  "homepage": "https://github.com/jupyterhub/nbgitpuller#readme"
+  }
 }


### PR DESCRIPTION
The version field isn't required unless we want to do `npm publish` which we don't. Most things in package.json can be removed actually, so I removed most things.

By removing repository and license, we got two warnings.

```
npm WARN nbgitpuller No repository field.
npm WARN nbgitpuller No license field.
```

I think this is fine, and that a slimmed package.json helps make this repo's code be more understandable. For reference, see [the package.json docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json).