### PR TITLE
Remove six from dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,4 @@
 jupyter_packaging>=0.10
-six
 pytest
 pytest-cov
 flake8


### PR DESCRIPTION
My understanding is that `six` is a tool related to python version compatibility.

> "Six is a Python 2 and 3 compatibility library. It provides utility functions for smoothing over the differences between the Python versions with the goal of writing Python code that is compatible on both Python versions. See the documentation for more information on what is provided."

There is no reference to `six` in our source code any more.