### PR TITLE
Remove requirement of notebook

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 flake8
 nbclassic
+notebook>=5.5.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     platforms='any',
-    install_requires=['notebook>=5.5.0', 'jupyter_server>=1.10.1', 'tornado'],
+    install_requires=['jupyter_server>=1.10.1', 'tornado'],
     data_files=[
         ('etc/jupyter/jupyter_server_config.d', ['nbgitpuller/etc/jupyter_server_config.d/nbgitpuller.json']),
         ('etc/jupyter/jupyter_notebook_config.d', ['nbgitpuller/etc/jupyter_notebook_config.d/nbgitpuller.json'])


### PR DESCRIPTION
I don't think we require notebook any more, but we do require jupyter_server now and our tests need to test against notebook still which it should still function against.

Closes #209 