### PR TITLE
Fix jupyter-packaging reference, use - instead of _

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-jupyter_packaging>=0.10
+jupyter-packaging>=0.10
 pytest
 pytest-cov
 flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "build",
-  "jupyter_packaging>=0.10",
+  "jupyter-packaging>=0.10",
   "setuptools",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
While `pip` can handle the use of `_` in the name `jupyter_packaging`, our conda feedstock can't. According to pypi and the conda feedstock, it should be `jupyter-packaging`.
