### PR TITLE
Point people to the browser extension

### DIFF
--- a/docs/link.rst
+++ b/docs/link.rst
@@ -5,9 +5,9 @@ Use the following form to create your own ``nbgitpuller`` links.
 
 .. note::
 
-  Consider using the `nbgitpuller link generator browser extension <https://github.com/yuvipanda/nbgitpuller-link-generator-webextension>`_
-  instead! Available for `Firefox <https://addons.mozilla.org/en-US/firefox/addon/nbgitpuller-link-generator/>`_ and
-  `Chrome <https://github.com/yuvipanda/nbgitpuller-link-generator-webextension#on-google-chrome--chromium>`_.
+   Consider using the `nbgitpuller link generator browser extension <https://github.com/yuvipanda/nbgitpuller-link-generator-webextension>`_
+   instead! Available for `Firefox <https://addons.mozilla.org/en-US/firefox/addon/nbgitpuller-link-generator/>`_ and
+   `Chrome <https://github.com/yuvipanda/nbgitpuller-link-generator-webextension#on-google-chrome--chromium>`_.
 
 
 

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -3,6 +3,14 @@ nbgitpuller link generator
 
 Use the following form to create your own ``nbgitpuller`` links.
 
+.. note::
+
+  Consider using the `nbgitpuller link generator browser extension <https://github.com/yuvipanda/nbgitpuller-link-generator-webextension>`_
+  instead! Available for `Firefox <https://addons.mozilla.org/en-US/firefox/addon/nbgitpuller-link-generator/>`_ and
+  `Chrome <https://github.com/yuvipanda/nbgitpuller-link-generator-webextension#on-google-chrome--chromium>`_.
+
+
+
 .. raw:: html
 
    <div class="container full-width">


### PR DESCRIPTION
It is less error prone for the most common use case,
as you can just browse on GitHub and get the link immediately.
No need to figure out branch name, filepath, etc.

See launch announcement in https://words.yuvi.in/post/nbgitpuller-link-generator-extension/