### PR TITLE
docs: adds docstrings (refactor: rename local parameter)

### DIFF
--- a/nbgitpuller/__init__.py
+++ b/nbgitpuller/__init__.py
@@ -6,13 +6,30 @@ from tornado.web import StaticFileHandler
 import os
 
 
-def _jupyter_server_extension_paths():
+def _jupyter_server_extension_points():
+    """
+    This function is detected by `notebook` and `jupyter_server` because they
+    are explicitly configured to inspect the nbgitpuller module for it. That
+    explicit configuration is passed via setup.py's declared data_files.
+
+    Returns a list of dictionaries with metadata describing where to find the
+    `_load_jupyter_server_extension` function.
+    """
     return [{
         'module': 'nbgitpuller',
     }]
 
 
-def load_jupyter_server_extension(nbapp):
+def _load_jupyter_server_extension(nbapp):
+    """
+    This function is a hook for `notebook` and `jupyter_server` that we use to
+    register additional endpoints to be handled by nbgitpuller.
+
+    Related documentation:
+    - notebook: https://jupyter-notebook.readthedocs.io/en/stable/extending/handlers.htmland
+    - notebook: https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html#Example---Server-extension
+    - jupyter_server: https://jupyter-server.readthedocs.io/en/latest/developers/extensions.html
+    """
     web_app = nbapp.web_app
     base_url = url_path_join(web_app.settings['base_url'], 'git-pull')
     handlers = [
@@ -29,4 +46,19 @@ def load_jupyter_server_extension(nbapp):
     web_app.settings['nbapp'] = nbapp
     web_app.add_handlers('.*', handlers)
 
-_load_jupyter_server_extension = load_jupyter_server_extension
+
+# For compatibility with both notebook and jupyter_server, we define
+# _jupyter_server_extension_paths alongside _jupyter_server_extension_points.
+#
+# "..._paths" is used by notebook and still supported by jupyter_server as of
+# jupyter_server 1.13.3, but was renamed to "..._points" in jupyter_server
+# 1.0.0.
+#
+_jupyter_server_extension_paths = _jupyter_server_extension_points
+
+# For compatibility with both notebook and jupyter_server, we define both
+# load_jupyter_server_extension alongside _load_jupyter_server_extension.
+#
+# "load..." is used by notebook and "_load..." is used by jupyter_server.
+#
+load_jupyter_server_extension = _load_jupyter_server_extension

--- a/nbgitpuller/__init__.py
+++ b/nbgitpuller/__init__.py
@@ -20,17 +20,20 @@ def _jupyter_server_extension_points():
     }]
 
 
-def _load_jupyter_server_extension(nbapp):
+def _load_jupyter_server_extension(app):
     """
     This function is a hook for `notebook` and `jupyter_server` that we use to
     register additional endpoints to be handled by nbgitpuller.
+
+    Note that as this function is used as a hook for both notebook and
+    jupyter_server, the argument passed may be a NotebookApp or a ServerApp.
 
     Related documentation:
     - notebook: https://jupyter-notebook.readthedocs.io/en/stable/extending/handlers.htmland
     - notebook: https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Distributing%20Jupyter%20Extensions%20as%20Python%20Packages.html#Example---Server-extension
     - jupyter_server: https://jupyter-server.readthedocs.io/en/latest/developers/extensions.html
     """
-    web_app = nbapp.web_app
+    web_app = app.web_app
     base_url = url_path_join(web_app.settings['base_url'], 'git-pull')
     handlers = [
         (url_path_join(base_url, 'api'), SyncHandler),
@@ -43,7 +46,10 @@ def _load_jupyter_server_extension(nbapp):
             {'path': os.path.join(os.path.dirname(__file__), 'static')}
         )
     ]
-    web_app.settings['nbapp'] = nbapp
+    # FIXME: See note on how to stop relying on settings to pass information:
+    #        https://github.com/jupyterhub/nbgitpuller/pull/242#pullrequestreview-854968180
+    #
+    web_app.settings['nbapp'] = app
     web_app.add_handlers('.*', handlers)
 
 

--- a/nbgitpuller/handlers.py
+++ b/nbgitpuller/handlers.py
@@ -180,6 +180,12 @@ class UIHandler(IPythonHandler):
 
 
 class LegacyGitSyncRedirectHandler(IPythonHandler):
+    """
+    The /git-pull endpoint was previously exposed /git-sync.
+
+    For backward compatibility we keep listening to the /git-sync endpoint but
+    respond with a redirect to the /git-pull endpoint.
+    """
     @web.authenticated
     @gen.coroutine
     def get(self):
@@ -191,6 +197,12 @@ class LegacyGitSyncRedirectHandler(IPythonHandler):
 
 
 class LegacyInteractRedirectHandler(IPythonHandler):
+    """
+    The /git-pull endpoint was previously exposed /interact.
+
+    For backward compatibility we keep listening to the /interact endpoint but
+    respond with a redirect to the /git-pull endpoint.
+    """
     @web.authenticated
     @gen.coroutine
     def get(self):


### PR DESCRIPTION
This PR combines pure documentation commits with a refactoring commit that merits more closer review.

I'm not 100% it's non-breaking for all users to rename `nbapp` to `app` in the settings. To my knowledge, we only set it to be able to read it from this code base. For reference, setting `nbapp` in settings was introduced in #75.