### PR TITLE
Fix sync problems after deleting files

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -262,6 +262,9 @@ class GitPuller(Configurable):
         # a fresh copy of a file they might have screwed up.
         yield from self.reset_deleted_files()
 
+        # Unstage all changes, otherwise the merge might fail
+        yield from execute_cmd(['git', 'reset'], cwd=self.repo_dir)
+
         # If there are local changes, make a commit so we can do merges when pulling
         # We also allow empty commits. On NFS (at least), sometimes repo_is_dirty returns a false
         # positive, returning True even when there are no local changes (git diff-files seems to return

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -172,7 +172,7 @@ class GitPuller(Configurable):
 
         for filename in deleted_files:
             if filename:  # Filter out empty lines
-                yield from execute_cmd(['git', 'checkout', 'origin/{}'.format(self.branch_name), '--', filename], cwd=self.repo_dir)
+                yield from execute_cmd(['git', 'checkout', '--', filename], cwd=self.repo_dir)
 
     def repo_is_dirty(self):
         """

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -262,8 +262,10 @@ class GitPuller(Configurable):
         # a fresh copy of a file they might have screwed up.
         yield from self.reset_deleted_files()
 
-        # Unstage all changes, otherwise the merge might fail
-        yield from execute_cmd(['git', 'reset'], cwd=self.repo_dir)
+        # Unstage any changes, otherwise the merge might fail.
+        # The following command resets the index, but keeps the working tree.  All changes
+        # to files will be preserved, but they are no longer staged for commit.
+        yield from execute_cmd(['git', 'reset', '--mixed'], cwd=self.repo_dir)
 
         # If there are local changes, make a commit so we can do merges when pulling
         # We also allow empty commits. On NFS (at least), sometimes repo_is_dirty returns a false

--- a/tests/test_gitpuller.py
+++ b/tests/test_gitpuller.py
@@ -73,6 +73,8 @@ class Puller(Repository):
     def __enter__(self):
         print()
         self.pull_all()
+        self.git('config', '--local', 'user.email', 'puller@example.com')
+        self.git('config', '--local', 'user.name', 'puller')
         return self
 
 

--- a/tests/test_gitpuller.py
+++ b/tests/test_gitpuller.py
@@ -396,6 +396,28 @@ def test_delete_locally_and_remotely():
             assert puller.read_file('another_file.txt') == '2'
 
 
+def test_sync_with_staged_changes():
+    """
+    Test that we can sync even if there are staged changess
+    """
+
+    with Remote() as remote, Pusher(remote) as pusher:
+        pusher.push_file('README.md', '1')
+
+        with Puller(remote) as puller:
+            assert puller.read_file('README.md') == pusher.read_file('README.md') == '1'
+
+            # Change a file locally and remotely
+            puller.write_file('README.md', 'student changed')
+            pusher.push_file('README.md', 'teacher changed')
+            
+            # Stage the local change, but do not commit
+            puller.git('add', 'README.md')
+
+            # Try to sync
+            puller.pull_all()
+
+
 @pytest.fixture(scope='module')
 def long_remote():
     with Remote("long_remote") as remote, Pusher(remote, "lr_pusher") as pusher:

--- a/tests/test_gitpuller.py
+++ b/tests/test_gitpuller.py
@@ -323,6 +323,29 @@ def test_reset_file():
             assert puller.read_file('README.md') == pusher.read_file('README.md') == '1'
             assert puller.read_file('unicode🙂.txt') == pusher.read_file('unicode🙂.txt') == '2'
 
+def test_delete_conflicted_file():
+    """
+    Test that after deleting a file that had a conflict, we can still pull
+    """
+    with Remote() as remote, Pusher(remote) as pusher:
+        pusher.push_file('README.md', 'hello')
+
+        with Puller(remote) as puller:
+            # Change a file locally
+            puller.write_file('README.md', 'student changed')
+
+            # Sync will keep the local change
+            puller.pull_all()            
+            assert puller.read_file('README.md') == 'student changed'
+
+            # Delete previously changed file
+            os.remove(os.path.join(puller.path, 'README.md'))
+
+            # Make a change remotely.  We should be able to pull it
+            pusher.push_file('new_file.txt', 'hello world')
+            puller.pull_all()
+
+
 
 @pytest.fixture(scope='module')
 def long_remote():


### PR DESCRIPTION
Hi, we have encountered problems when sometimes syncing would fail after deleting files. Issue #254 happens after you change a file locally, sync, then nbgitpuller keeps your changes, and then you delete the file. Issue #234 seems related, and happens when you delete a file locally, and from the repository.

This pull request tries to fix both bugs. First, in `reset_deleted_files()`, I don't checkout from the remote branch, because the file might not exist there anymore. Instead, I checkout from the local branch, and trust that the merge will give me the updated version. Second, I issue a `git reset` in order to unstage files. Staged files that might be lying around (for example from a failed merge, without this patch) prevent a proper merge.

I think this is the minimal change that fixes the sync problems. I also added some test cases for the issues. Please have a look if everything makes sense, I am not sure that I didn't miss any corner case!

(I should mention that I first made another version that does something like `git stash; git pull --ff-only; git stash pop -Xours`. It had the advantage of not introducing extra commits and keeping history clean, and also passes tests. But then I came up with this solution, since I wanted to touch the merging code as little as possible...).