### PR TITLE
Add binder-badge bot

### DIFF
--- a/.github/workflows/binder-badge.yml
+++ b/.github/workflows/binder-badge.yml
@@ -1,0 +1,18 @@
+name: binder-badge
+on:
+  pull_request_target:
+
+jobs:
+  badge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: manics/action-binderbadge@v1.0.0
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          persistentLink: false
+          updateDescription: true
+          urlpath: git-pull?repo=https%3A%2F%2Fgithub.com%2Fjupyterhub%2Fnbgitpuller&urlpath=lab%2Ftree%2FREADME.md&branch=main


### PR DESCRIPTION
This is an optional add-on to https://github.com/jupyterhub/nbgitpuller/pull/258

This will update a PR description (so avoids the noise of a new comment) with a mybinder.org badge that builds the PR on mybinder.org, and redirects to nbgitpuller to clone a repo, for now I've picked https://github.com/jupyterhub/nbgitpuller

See e.g. https://github.com/manics/nbgitpuller/pull/2