### PR TITLE
Fix regression: can't reset some files anymore

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -170,9 +170,13 @@ class GitPuller(Configurable):
             'git', 'ls-files', '--deleted', '-z'
         ], cwd=self.repo_dir).decode().strip().split('\0')
 
+        paths = self.find_upstream_changed('D')
+        upstream_deleted = [fn[len(self.repo_dir) + 1:] for fn in paths]
+
         for filename in deleted_files:
-            if filename:  # Filter out empty lines
-                yield from execute_cmd(['git', 'checkout', '--', filename], cwd=self.repo_dir)
+            # Filter out empty lines, and files that were deleted in the remote
+            if filename and filename not in upstream_deleted:
+                yield from execute_cmd(['git', 'checkout', 'origin/{}'.format(self.branch_name), '--', filename], cwd=self.repo_dir)
 
     def repo_is_dirty(self):
         """

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -200,8 +200,8 @@ class GitPuller(Configurable):
         Return list of files that have been changed upstream belonging to a particular kind of change
         """
         output = subprocess.check_output([
-            'git', 'log', '..origin/{}'.format(self.branch_name),
-            '--oneline', '--name-status'
+            'git', 'diff', '..origin/{}'.format(self.branch_name),
+            '--name-status'
         ], cwd=self.repo_dir).decode()
         files = []
         for line in output.split('\n'):

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -170,9 +170,7 @@ class GitPuller(Configurable):
             'git', 'ls-files', '--deleted', '-z'
         ], cwd=self.repo_dir).decode().strip().split('\0')
 
-        paths = self.find_upstream_changed('D')
-        upstream_deleted = [fn[len(self.repo_dir) + 1:] for fn in paths]
-
+        upstream_deleted = self.find_upstream_changed('D')
         for filename in deleted_files:
             # Filter out empty lines, and files that were deleted in the remote
             if filename and filename not in upstream_deleted:
@@ -206,7 +204,7 @@ class GitPuller(Configurable):
         files = []
         for line in output.split('\n'):
             if line.startswith(kind):
-                files.append(os.path.join(self.repo_dir, line.split('\t', 1)[1]))
+                files.append(line.split('\t', 1)[1])
 
         return files
 
@@ -241,6 +239,7 @@ class GitPuller(Configurable):
         # Find what files have been added!
         new_upstream_files = self.find_upstream_changed('A')
         for f in new_upstream_files:
+            f = os.path.join(self.repo_dir, f)
             if os.path.exists(f):
                 # If there's a file extension, put the timestamp before that
                 ts = datetime.datetime.now().strftime('__%Y%m%d%H%M%S')

--- a/tests/test_gitpuller.py
+++ b/tests/test_gitpuller.py
@@ -402,6 +402,25 @@ def test_delete_conflicted_file():
             puller.pull_all()
 
 
+def test_delete_remotely_modify_locally():
+    """
+    Test that we can delete a file upstream, and edit it at the same time locally
+    """
+    with Remote() as remote, Pusher(remote) as pusher:
+        pusher.push_file('README.md', 'new')
+
+        with Puller(remote) as puller:
+            # Delete the file remotely
+            pusher.git('rm', 'README.md')
+            pusher.git('commit', '-m', 'Deleted file')
+            
+            # Edit locally
+            pusher.push_file('README.md', 'HELLO')
+            puller.pull_all()
+
+            assert puller.read_file('README.md') == 'HELLO'
+
+
 def test_delete_locally_and_remotely():
     """
     Test that sync works after deleting a file locally and remotely


### PR DESCRIPTION
Hi, unfortunately my recent pull request introduced another bug. Under some circumstances, you can't reset a file by deleting and pulling anymore. It happens when you:

- Modify a file locally
- Sync, and it keeps your change (this creates a commit in the local branch)
- Delete the file in order to reset it

The result is that it will get the file from the local branch, not the remote branch, so it is reset to an old version from the student.

When resetting, I changed `git checkout` back to use `origin/{branch_name}`. The merge afterwards did *not* always do the right thing. We still have to deal with the case that a file has been deleted upstream. For that, I just check if that is the case and then skip the file.

I've also added a fix for a related bug that I noticed at the same time. It happens when you delete the file remotely and edit it locally.