### PR TITLE
Deal with modify/delete conflicts

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -275,11 +275,13 @@ class GitPuller(Configurable):
                 yield line
                 
         except subprocess.CalledProcessError as exc:
-            for line in exc.output.decode().splitlines():
+            lines = exc.output.decode().splitlines()
+            for line in lines:
                 yield line
 
-            if exc.output.decode().startswith("CONFLICT (modify/delete)"):
-                raise ModifyDeleteConflict() from exc
+            for line in lines:
+                if line.startswith("CONFLICT (modify/delete)"):
+                    raise ModifyDeleteConflict() from exc
             raise
 
     def commit_all(self):

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -272,12 +272,12 @@ class GitPuller(Configurable):
             stderr=subprocess.STDOUT,
             env={**os.environ, 'LANG': 'C'}).decode().splitlines()
             for line in lines:
-                yield line
+                yield line + '\n'
                 
         except subprocess.CalledProcessError as exc:
             lines = exc.output.decode().splitlines()
             for line in lines:
-                yield line
+                yield line + '\n'
 
             for line in lines:
                 if line.startswith("CONFLICT (modify/delete)"):

--- a/tests/test_gitpuller.py
+++ b/tests/test_gitpuller.py
@@ -466,6 +466,40 @@ def test_diverged_reverse():
             assert(puller.read_file('README.md') == 'conflicting change')
 
 
+def test_diverged_multiple():
+    """
+    Test deleting a file upstream, and editing it locally.  We commit the changes
+    to create diverged branches.
+
+    Use two files, so git merge doesn't mention the conflict in the first line.
+
+        puller: Auto-merging AFILE.txt
+        puller: CONFLICT (modify/delete): BFILE.txt deleted in origin/master and modified in HEAD.  Version HEAD of BFILE.txt left in tree.
+        puller: Automatic merge failed; fix conflicts and then commit the result.
+
+    """
+    with Remote() as remote, Pusher(remote) as pusher:
+        pusher.push_file('AFILE.txt', 'new')
+        pusher.push_file('BFILE.txt', 'new')
+
+        with Puller(remote) as puller:
+            # Remote changes - BFILE.txt deleted    
+            pusher.write_file('AFILE.txt', 'changed remotely')
+            pusher.git('add', 'AFILE.txt')
+            pusher.git('rm', 'BFILE.txt')
+            pusher.git('commit', '-m', 'Remote changes')
+            pusher.git('push', '-u', 'origin', 'master')
+  
+            # Local changes - BFILE.txt edited
+            puller.write_file('AFILE.txt', 'edited')
+            puller.write_file('BFILE.txt', 'edited')
+            puller.git('commit', '-am', 'Make conflicting change')
+
+            puller.pull_all()
+            assert puller.read_file('AFILE.txt') == 'edited'
+            assert puller.read_file('BFILE.txt') == 'edited'
+
+
 def test_delete_locally_and_remotely():
     """
     Test that sync works after deleting a file locally and remotely


### PR DESCRIPTION
This pull request deals with the case where you have diverged branches - you delete a file remotely, and edit the same file locally, or vice versa. If the local change was committed previously, the sync will fail with `CONFLICT (modify/delete)`. See also https://github.com/jupyterhub/nbgitpuller/issues/265.

```
puller: $ git -c user.email=nbgitpuller@nbgitpuller.link -c user.name=nbgitpuller merge -Xours origin/master
puller: CONFLICT (modify/delete): README.md deleted in origin/master and modified in HEAD. Version HEAD of README.md left in tree.
puller: Automatic merge failed; fix conflicts and then commit the result.
```

What this does is, it checks for that error, and resolves it via `commit -a` (keeping all the local changes). This should be in line with the sync policy. We have tested this for about a week in production and so far it seems to work well.

Please let me know if I'm adding too many tests :-) I think maybe I could squash some together if it is getting too much.
