### PR TITLE
Make tests work with different default branch, or different locale

### DIFF
--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -16,6 +16,7 @@ def execute_cmd(cmd, **kwargs):
     yield '$ {}\n'.format(' '.join(cmd))
     kwargs['stdout'] = subprocess.PIPE
     kwargs['stderr'] = subprocess.STDOUT
+    kwargs['env'] = dict(os.environ, LANG='C')
 
     proc = subprocess.Popen(cmd, **kwargs)
 

--- a/nbgitpuller/pull.py
+++ b/nbgitpuller/pull.py
@@ -16,6 +16,8 @@ def execute_cmd(cmd, **kwargs):
     yield '$ {}\n'.format(' '.join(cmd))
     kwargs['stdout'] = subprocess.PIPE
     kwargs['stderr'] = subprocess.STDOUT
+    # Explicitly set LANG=C, as `git` commandline output will be different if
+    # the user environment has a different locale set!
     kwargs['env'] = dict(os.environ, LANG='C')
 
     proc = subprocess.Popen(cmd, **kwargs)

--- a/tests/repohelpers.py
+++ b/tests/repohelpers.py
@@ -18,7 +18,7 @@ class Repository:
 
     def __enter__(self):
         os.makedirs(self.path, exist_ok=True)
-        self.git('init', '--bare')
+        self.git('init', '--bare', '--initial-branch=master')
         return self
 
     def __exit__(self, *args):


### PR DESCRIPTION
This is a fix for #283. If the user changed the default branch name on their system, the tests would fail.

At the same time, I noticed some tests fail on my laptop with a German OS (LANG=de_DE.UTF-8). This is because we parse the output of `git`, which is different if the locale is not set to English. (Now that I think about it, it doesn't just affect the tests and is an actual bug, but I still left it in this PR because it is just a one-liner.)