### PR TITLE
fix handling of deleted-but-not-staged files with git 2.40

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           node-version: "${{ matrix.node-version }}"
 
+      - name: git version
+        run: git --version
+
       - name: Run webpack to build static assets
         run: |
           npm install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,20 +26,42 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
-        node-version: ["16"]
+        include:
+          - python-version: "3.7"
+          - python-version: "3.8"
+            # 2.17 is in ubuntu 18.04
+            git-version: "2.17"
+          - python-version: "3.9"
+            # 2.25 is in ubuntu 20.04
+            git-version: "2.25"
+          - python-version: "3.10"
+            # 2.34 is in ubuntu 22.04
+            git-version: "2.34"
+          - python-version: "3.11"
 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python-version }}"
+
       - uses: actions/setup-node@v3
         with:
-          node-version: "${{ matrix.node-version }}"
+          node-version: "${{ matrix.node-version || '16'}}"
+
+      - name: install git ${{ matrix.git-version }}
+        if: ${{ matrix.git-version }}
+        run: |
+          export MAMBA_ROOT_PREFIX=$/tmp/conda
+          mkdir -p $MAMBA_ROOT_PREFIX/bin
+          curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/1.4.2 | tar -xvj -C $MAMBA_ROOT_PREFIX/bin/ --strip-components=1 bin/micromamba
+          $MAMBA_ROOT_PREFIX/bin/micromamba install -c conda-forge -p $MAMBA_ROOT_PREFIX "git=${{ matrix.git-version }}"
+          echo "PATH=$MAMBA_ROOT_PREFIX/bin:$PATH" >> $GITHUB_ENV
 
       - name: git version
-        run: git --version
+        run: |
+          which git
+          git --version
 
       - name: Run webpack to build static assets
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,4 +76,4 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --verbose --maxfail=2 --color=yes --cov nbgitpuller
+          pytest --verbose --maxfail=2 --color=yes --cov nbgitpuller tests

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 jupyter-packaging>=0.10
 nbclassic
+packaging
 pytest
 pytest-cov

--- a/tests/repohelpers.py
+++ b/tests/repohelpers.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess as sp
 from uuid import uuid4
 
+from packaging.version import Version as V
 from nbgitpuller import GitPuller
 
 
@@ -18,7 +19,14 @@ class Repository:
 
     def __enter__(self):
         os.makedirs(self.path, exist_ok=True)
-        self.git('init', '--bare', '--initial-branch=master')
+
+        # --initial-branch added in git 2.28
+        git_version = self.git("--version").split()[-1]
+        if V(git_version) >= V("2.28"):
+            extra_args = ('--initial-branch=master',)
+        else:
+            extra_args = ()
+        self.git('init', '--bare', *extra_args)
         return self
 
     def __exit__(self, *args):


### PR DESCRIPTION
git 2.40 has apparently changed the handling of `git merge -Xours` when the file is:

- removed locally, but not checked in
- also removed remotely

to now conflict. It's unclear if this is a bug (I'm guessing it is). Running `git checkout HEAD -- DELETED_FILE` on the file prior to the pull does resolve the conflict, though.