### PR TITLE
Link generator - support generating links for named servers

### DIFF
--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -1,5 +1,5 @@
 // Pure function that generates an nbgitpuller URL
-function generateRegularUrl(hubUrl, urlPath, repoUrl, branch) {
+function generateRegularUrl(hubUrl, serverPath, urlPath, repoUrl, branch) {
 
     // assume hubUrl is a valid URL
     var url = new URL(hubUrl);
@@ -17,7 +17,12 @@ function generateRegularUrl(hubUrl, urlPath, repoUrl, branch) {
     if (!url.pathname.endsWith('/')) {
         url.pathname += '/'
     }
-    url.pathname += 'hub/user-redirect/git-pull';
+
+    if (serverPath) {
+        url.pathname += 'hub/user-redirect/'+serverPath+'/git-pull';
+    } else {
+        url.pathname += 'hub/user-redirect/git-pull';
+    }
 
     return url.toString();
 }
@@ -160,6 +165,7 @@ function displayLink() {
         var contentRepoUrl = document.getElementById('content-repo').value;
         var contentRepoBranch = document.getElementById('content-branch').value;
         var filePath = document.getElementById('filepath').value;
+        var server = document.getElementById('server').value;
         var appName = form.querySelector('input[name="app"]:checked').value;
         var activeTab = document.querySelector(".nav-link.active").id;
 
@@ -178,7 +184,7 @@ function displayLink() {
 
         if (activeTab === "tab-auth-default") {
             document.getElementById('default-link').value = generateRegularUrl(
-                hubUrl, urlPath, repoUrl, branch
+                hubUrl, server, urlPath, repoUrl, branch
             );
         } else if (activeTab === "tab-auth-canvas"){
             document.getElementById('canvas-link').value = generateCanvasUrl(

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -172,6 +172,17 @@ Use the following form to create your own ``nbgitpuller`` links.
              </div>
            </div>
 
+           <div class="form-group row" id="server-container">
+            <label for="server" class="col-sm-2 col-form-label">Named Server to open</label>
+            <div class="col-sm-10">
+              <input class="form-control" type="text" id="server" placeholder="NamedServer"
+                oninput="displayLink()">
+              <small class="form-text text-muted">
+                Use for specific <a href="https://jupyterhub.readthedocs.io/en/stable/howto/configuration/config-user-env.html#named-servers">named server</a> Jupyter server instance.
+              </small>
+            </div>
+          </div>
+
        </form>
      </div>
      <br /><br /><br />


### PR DESCRIPTION
This should add an optional property to the form that generates links that will allow support for named servers.

Ref #307

---

Summary edit by Erik:

- closes #307

Documentation review snapshot from https://nbgitpuller--309.org.readthedocs.build/en/309/:

![image](https://github.com/jupyterhub/nbgitpuller/assets/3837114/c52b1229-a702-4d6a-b3d1-39630b1a052a)
