### PR TITLE
Removal of Python 3.7 due to EOL 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.7"
           - python-version: "3.8"
             # 2.17 is in ubuntu 18.04
             git-version: "2.17"


### PR DESCRIPTION
Removal of Python 3.7 due to EOL 
https://devguide.python.org/versions/