### PR TITLE
include xsrf token in event stream request

### DIFF
--- a/nbgitpuller/static/js/gitsync.js
+++ b/nbgitpuller/static/js/gitsync.js
@@ -1,5 +1,5 @@
 export class GitSync {
-    constructor(baseUrl, repo, branch, depth, targetpath, path) {
+    constructor(baseUrl, repo, branch, depth, targetpath, path, xsrf) {
         // Class that talks to the API backend & emits events as appropriate
         this.baseUrl = baseUrl;
         this.repo = repo;
@@ -7,6 +7,7 @@ export class GitSync {
         this.depth = depth;
         this.targetpath = targetpath;
         this.redirectUrl = baseUrl + path;
+        this._xsrf = xsrf;
 
         this.callbacks = {};
     }
@@ -30,6 +31,7 @@ export class GitSync {
     start() {
         // Start git pulling handled by SyncHandler, declared in handlers.py
         let syncUrlParams = new URLSearchParams({
+            _xsrf: this._xsrf,
             repo: this.repo,
             targetpath: this.targetpath
         });

--- a/nbgitpuller/static/js/index.js
+++ b/nbgitpuller/static/js/index.js
@@ -21,7 +21,8 @@ const gs = new GitSync(
     getBodyData('branch'),
     getBodyData('depth'),
     getBodyData('targetpath'),
-    getBodyData('path')
+    getBodyData('path'),
+    getBodyData('xsrf'),
 );
 
 const gsv = new GitSyncView(

--- a/nbgitpuller/templates/status.html
+++ b/nbgitpuller/templates/status.html
@@ -5,6 +5,7 @@
 data-base-url="{{ base_url | urlencode }}"
 data-repo="{{ repo | urlencode }}"
 data-path="{{ path | urlencode }}"
+data-xsrf="{{ xsrf_token | urlencode }}"
 {% if branch %}data-branch="{{ branch | urlencode }}"{% endif %}
 {% if depth %}data-depth="{{ depth | urlencode }}"{% endif %}
 data-targetpath="{{ targetpath | urlencode }}"


### PR DESCRIPTION
JupyterHub 4.1 increases strictness of xsrf checks (omitting it is no longer allowed on GET requests that are `Sec-Fetch: cors`, which includes this EventStream).

closes #344 