### PR TITLE
403 on failed auth for EventStream

### DIFF
--- a/nbgitpuller/handlers.py
+++ b/nbgitpuller/handlers.py
@@ -29,6 +29,12 @@ class SyncHandler(JupyterHandler):
         if 'git_lock' not in self.settings:
             self.settings['git_lock'] = locks.Lock()
 
+    def get_login_url(self):
+        # raise on failed auth, not redirect
+        # can't redirect EventStream to login
+        # same as Jupyter's APIHandler
+        raise web.HTTPError(403)
+
     @property
     def git_lock(self):
         return self.settings['git_lock']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,7 +136,7 @@ def test_clone_auth(jupyterdir, jupyter_server):
         }
         r = request_api(params)
         # no token, redirect to login
-        assert r.code == 302
+        assert r.code == 403
 
 
 def test_clone_targetpath(jupyterdir, jupyter_server):


### PR DESCRIPTION
302 redirects should only be on for-humans pages, since the EventStream request can't follow the login process.