### PR TITLE
Add copy button for link generator

### DIFF
--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -286,6 +286,7 @@ function linkMain() {
 
 function copyLink(elementId) {
   var copyText = document.getElementById(elementId);
-  copyText.focus();
+  copyText.select();
+  copyText.setSelectionRange(0, copyText.value.length);
   navigator.clipboard.writeText(copyText.value);
 } 

--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -286,7 +286,6 @@ function linkMain() {
 
 function copyLink(elementId) {
   var copyText = document.getElementById(elementId);
-  copyText.select();
-  copyText.setSelectionRange(0, 99999);
+  copyText.focus();
   navigator.clipboard.writeText(copyText.value);
 } 

--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -283,3 +283,10 @@ function linkMain() {
     // Do an initial render, to make sure our disabled / enabled properties are correctly set
     render();
 }
+
+function copyLink(elementId) {
+  var copyText = document.getElementById(elementId);
+  copyText.select();
+  copyText.setSelectionRange(0, 99999);
+  navigator.clipboard.writeText(copyText.value);
+} 

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -203,6 +203,7 @@ Use the following form to create your own ``nbgitpuller`` links.
       .input-group {
           display: flex;
           align-items: center;
+          margin: 10px;
       }
       .input-group input {
           flex: 1;

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -40,19 +40,19 @@ Use the following form to create your own ``nbgitpuller`` links.
              <div class="tab-content">
               <div class="tab-pane fade show active" id="auth-default" role="tabpanel" aria-labelledby="tab-auth-default" tabindex="0">
                   <div class="input-group">
-                      <input type="text" readonly class="form-control form-control" id="default-link" name="auth-default-link" placeholder="Generated link appears here...">
+                      <input type="text" readonly class="form-control" id="default-link" name="auth-default-link" placeholder="Generated link appears here...">
                       <button class="btn btn-outline-secondary" type="button" onclick="copyLink('default-link')">Copy</button>
                   </div>
               </div>
               <div class="tab-pane fade" id="auth-canvas" role="tabpanel" aria-labelledby="tab-auth-canvas" tabindex="0">
                   <div class="input-group">
-                      <input type="text" readonly class="form-control form-control" id="canvas-link" name="auth-canvas-link" placeholder="Generated canvas 'external app' link appears here...">
+                      <input type="text" readonly class="form-control" id="canvas-link" name="auth-canvas-link" placeholder="Generated canvas 'external app' link appears here...">
                       <button class="btn btn-outline-secondary" type="button" onclick="copyLink('canvas-link')">Copy</button>
                   </div>
               </div>
               <div class="tab-pane fade" id="auth-binder" role="tabpanel" aria-labelledby="tab-auth-binder" tabindex="0">
                   <div class="input-group">
-                      <input type="text" readonly class="form-control form-control" id="binder-link" name="auth-binder-link" placeholder="Generated Binder link appears here...">
+                      <input type="text" readonly class="form-control" id="binder-link" name="auth-binder-link" placeholder="Generated Binder link appears here...">
                       <button class="btn btn-outline-secondary" type="button" onclick="copyLink('binder-link')">Copy</button>
                   </div>
               </div>

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -38,17 +38,25 @@ Use the following form to create your own ``nbgitpuller`` links.
              </ul>
 
              <div class="tab-content">
-               <div class="tab-pane fade show active" id="auth-default" role="tabpanel" aria-labelledby="tab-auth-default" tabindex="0">
-                 <input type="text" readonly class="form-control form-control" id="default-link" name="auth-default-link" placeholder="Generated link appears here...">
-               </div>
-               <div class="tab-pane fade" id="auth-canvas" role="tabpanel" aria-labelledby="tab-auth-canvas"  tabindex="0">
-                 <input type="text" readonly class="form-control form-control" id="canvas-link" name="auth-canvas-link" placeholder="Generated canvas 'external app' link appears here...">
-               </div>
-               <div class="tab-pane fade" id="auth-binder" role="tabpanel" aria-labelledby="tab-auth-binder"  tabindex="0">
-                 <input type="text" readonly class="form-control form-control" id="binder-link" name="auth-binder-link" placeholder="Generated Binder link appears here...">
-               </div>
+              <div class="tab-pane fade show active" id="auth-default" role="tabpanel" aria-labelledby="tab-auth-default" tabindex="0">
+                  <div class="input-group">
+                      <input type="text" readonly class="form-control form-control" id="default-link" name="auth-default-link" placeholder="Generated link appears here...">
+                      <button class="btn btn-outline-secondary" type="button" onclick="copyLink('default-link')">Copy</button>
+                  </div>
+              </div>
+              <div class="tab-pane fade" id="auth-canvas" role="tabpanel" aria-labelledby="tab-auth-canvas" tabindex="0">
+                  <div class="input-group">
+                      <input type="text" readonly class="form-control form-control" id="canvas-link" name="auth-canvas-link" placeholder="Generated canvas 'external app' link appears here...">
+                      <button class="btn btn-outline-secondary" type="button" onclick="copyLink('canvas-link')">Copy</button>
+                  </div>
+              </div>
+              <div class="tab-pane fade" id="auth-binder" role="tabpanel" aria-labelledby="tab-auth-binder" tabindex="0">
+                  <div class="input-group">
+                      <input type="text" readonly class="form-control form-control" id="binder-link" name="auth-binder-link" placeholder="Generated Binder link appears here...">
+                      <button class="btn btn-outline-secondary" type="button" onclick="copyLink('binder-link')">Copy</button>
+                  </div>
+              </div>
              </div>
-           </div>
 
            <div class="form-group row">
              <label for="hub" class="col-sm-2 col-form-label">JupyterHub URL</label>
@@ -191,6 +199,19 @@ Use the following form to create your own ``nbgitpuller`` links.
          // load link javascript on page load
          window.addEventListener("load", linkMain);
      </script>
+    <style>
+      .input-group {
+          display: flex;
+          align-items: center;
+      }
+      .input-group input {
+          flex: 1;
+          margin-right: 5px;
+      }
+      .input-group button {
+          flex-shrink: 0;
+      }
+    </style>
 
 
 **Pre-populating some fields in the link generator**

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -37,22 +37,22 @@ Use the following form to create your own ``nbgitpuller`` links.
                </li>
              </ul>
 
-             <div class="tab-content">
+             <div class="tab-content" style="margin:10px;">
               <div class="tab-pane fade show active" id="auth-default" role="tabpanel" aria-labelledby="tab-auth-default" tabindex="0">
                   <div class="input-group">
-                      <input type="text" readonly class="form-control" id="default-link" name="auth-default-link" placeholder="Generated link appears here...">
+                      <input type="text" readonly class="form-control col-sm-2 col-form-label" id="default-link" name="auth-default-link" placeholder="Generated link appears here...">
                       <button class="btn btn-outline-secondary" type="button" onclick="copyLink('default-link')">Copy</button>
                   </div>
               </div>
               <div class="tab-pane fade" id="auth-canvas" role="tabpanel" aria-labelledby="tab-auth-canvas" tabindex="0">
                   <div class="input-group">
-                      <input type="text" readonly class="form-control" id="canvas-link" name="auth-canvas-link" placeholder="Generated canvas 'external app' link appears here...">
+                      <input type="text" readonly class="form-control col-sm-2 col-form-label" id="canvas-link" name="auth-canvas-link" placeholder="Generated canvas 'external app' link appears here...">
                       <button class="btn btn-outline-secondary" type="button" onclick="copyLink('canvas-link')">Copy</button>
                   </div>
               </div>
               <div class="tab-pane fade" id="auth-binder" role="tabpanel" aria-labelledby="tab-auth-binder" tabindex="0">
                   <div class="input-group">
-                      <input type="text" readonly class="form-control" id="binder-link" name="auth-binder-link" placeholder="Generated Binder link appears here...">
+                      <input type="text" readonly class="form-control col-sm-2 col-form-label" id="binder-link" name="auth-binder-link" placeholder="Generated Binder link appears here...">
                       <button class="btn btn-outline-secondary" type="button" onclick="copyLink('binder-link')">Copy</button>
                   </div>
               </div>
@@ -199,20 +199,6 @@ Use the following form to create your own ``nbgitpuller`` links.
          // load link javascript on page load
          window.addEventListener("load", linkMain);
      </script>
-    <style>
-      .input-group {
-          display: flex;
-          align-items: center;
-          margin: 10px;
-      }
-      .input-group input {
-          flex: 1;
-          margin-right: 5px;
-      }
-      .input-group button {
-          flex-shrink: 0;
-      }
-    </style>
 
 
 **Pre-populating some fields in the link generator**


### PR DESCRIPTION
I added a copy button for the generated link field to make it easier for users. I don't consider myself much of a web developer, but maybe it's not totally wrong. 😃 

![image](https://github.com/jupyterhub/nbgitpuller/assets/36420801/220e9668-8b83-4d30-920c-d1c0802daab7)
