### PR TITLE
Handle extra trailing slash when determining default targetpath

### DIFF
--- a/nbgitpuller/handlers.py
+++ b/nbgitpuller/handlers.py
@@ -154,8 +154,11 @@ class UIHandler(JupyterHandler):
                   self.get_argument('subPath', '.')
         app = self.get_argument('app', app_env)
         parent_reldir = os.getenv('NBGITPULLER_PARENTPATH', '')
+        # Remove trailing slashes before determining default targetPath
+        # Otherwise we end up with targetpath being `.`, which always exists (given it is current
+        # working directory) and we end up with weird failures
         targetpath = self.get_argument('targetpath', None) or \
-                     self.get_argument('targetPath', repo.split('/')[-1])
+                     self.get_argument('targetPath', repo.rstrip('/').split('/')[-1])
 
         if urlPath:
             path = urlPath


### PR DESCRIPTION
Otherwise we end up with targetpath being `.`, which always exists (given it is current working directory) and we end up with weird failures

Discovered while working on https://github.com/2i2c-org/infrastructure/issues/4576