### PR TITLE
Update style-sheet links to reflect those from `jupyter-server`

### DIFF
--- a/nbgitpuller/templates/page.html
+++ b/nbgitpuller/templates/page.html
@@ -5,7 +5,9 @@
     <meta charset="utf-8">
     <title>{% block title %}Jupyter Server{% endblock %}</title>
     {% block favicon %}<link id="favicon" rel="shortcut icon" type="image/x-icon" href="{{ static_url("favicon.ico") }}">{% endblock %}
-    <link rel="stylesheet" href="{{static_url("style/style.min.css") }}" />
+    <link rel="stylesheet" href="{{static_url("style/bootstrap.min.css") }}" />
+    <link rel="stylesheet" href="{{static_url("style/bootstrap-theme.min.css") }}" />
+    <link rel="stylesheet" href="{{static_url("style/index.css") }}" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 


### PR DESCRIPTION
At some point the `jupyter-server` project switched from including a combined style-sheet in their `page.html` template to including three distinct style-sheets.  

This pull request changes the head block of the template `page.html` packaged with `nbgitpuller` to be consistent with the template of the same name from the `jupyter-server` package.

This change resolves https://github.com/jupyterhub/nbgitpuller/issues/358