### PR TITLE
Add targetPath to link generator.

### DIFF
--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -1,5 +1,5 @@
 // Pure function that generates an nbgitpuller URL
-function generateRegularUrl(hubUrl, serverPath, urlPath, repoUrl, branch) {
+function generateRegularUrl(hubUrl, serverPath, urlPath, repoUrl, branch, targetPath) {
 
     // assume hubUrl is a valid URL
     var url = new URL(hubUrl);
@@ -12,6 +12,10 @@ function generateRegularUrl(hubUrl, serverPath, urlPath, repoUrl, branch) {
 
     if (branch) {
         url.searchParams.set('branch', branch);
+    }
+
+    if (targetPath) {
+        url.searchParams.set('targetPath', targetPath);
     }
 
     if (!url.pathname.endsWith('/')) {
@@ -27,7 +31,7 @@ function generateRegularUrl(hubUrl, serverPath, urlPath, repoUrl, branch) {
     return url.toString();
 }
 
-function generateCanvasUrl(hubUrl, urlPath, repoUrl, branch) {
+function generateCanvasUrl(hubUrl, urlPath, repoUrl, branch, targetPath) {
     // assume hubUrl is a valid URL
     var url = new URL(hubUrl);
 
@@ -43,6 +47,10 @@ function generateCanvasUrl(hubUrl, urlPath, repoUrl, branch) {
         nextUrlParams.append('branch', branch);
     }
 
+    if (targetPath) {
+        nextUrlParams.append('targetPath', targetPath);
+    }
+
     var nextUrl = '/hub/user-redirect/git-pull?' + nextUrlParams.toString();
 
     if (!url.pathname.endsWith('/')) {
@@ -55,7 +63,7 @@ function generateCanvasUrl(hubUrl, urlPath, repoUrl, branch) {
 }
 
 function generateBinderUrl(hubUrl, userName, repoName, branch, urlPath,
-    contentRepoUrl, contentRepoBranch) {
+    contentRepoUrl, contentRepoBranch, targetPath) {
 
     var url = new URL(hubUrl);
 
@@ -69,6 +77,10 @@ function generateBinderUrl(hubUrl, userName, repoName, branch, urlPath,
 
     if (contentRepoBranch) {
         nextUrlParams.append('branch', contentRepoBranch);
+    }
+
+    if (targetPath) {
+        nextUrlParams.append('targetPath', targetPath);
     }
 
     var nextUrl = 'git-pull?' + nextUrlParams.toString();
@@ -168,6 +180,7 @@ function displayLink() {
         var server = document.getElementById('server').value;
         var appName = form.querySelector('input[name="app"]:checked').value;
         var activeTab = document.querySelector(".nav-link.active").id;
+        var targetPath = document.getElementById('targetPath').value;
 
         if (appName === 'custom') {
             var urlPath = document.getElementById('urlpath').value;
@@ -184,11 +197,11 @@ function displayLink() {
 
         if (activeTab === "tab-auth-default") {
             document.getElementById('default-link').value = generateRegularUrl(
-                hubUrl, server, urlPath, repoUrl, branch
+                hubUrl, server, urlPath, repoUrl, branch, targetPath
             );
         } else if (activeTab === "tab-auth-canvas"){
             document.getElementById('canvas-link').value = generateCanvasUrl(
-                hubUrl, urlPath, repoUrl, branch
+                hubUrl, urlPath, repoUrl, branch, targetPath
             );
         } else if (activeTab === "tab-auth-binder"){
             // FIXME: userName parsing using new URL(...) assumes a
@@ -196,7 +209,7 @@ function displayLink() {
             // BinderHub link for SSH URLs? Then let's fix this parsing.
             var userName = new URL(repoUrl).pathname.split('/')[1];
             document.getElementById('binder-link').value = generateBinderUrl(
-                hubUrl, userName, repoName, branch, urlPath, contentRepoUrl, contentRepoBranch
+                hubUrl, userName, repoName, branch, urlPath, contentRepoUrl, contentRepoBranch, targetPath
             );
         }
     }
@@ -289,4 +302,4 @@ function copyLink(elementId) {
   copyText.select();
   copyText.setSelectionRange(0, copyText.value.length);
   navigator.clipboard.writeText(copyText.value);
-} 
+}

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -180,6 +180,17 @@ Use the following form to create your own ``nbgitpuller`` links.
              </div>
            </div>
 
+           <div class="form-group row">
+             <label for="targetPath" class="col-sm-2 col-form-label">Target Path</label>
+             <div class="col-sm-10">
+               <input class="form-control" type="text" id="targetPath" placeholder="(optional) Directory to clone into"
+                 oninput="displayLink()">
+               <small class="form-text text-muted">
+                 Directory to clone the repository into. If left blank, the repo will be cloned into a directory named after the repository.
+               </small>
+             </div>
+           </div>
+
            <div class="form-group row" id="server-container">
             <label for="server" class="col-sm-2 col-form-label">Named Server to open</label>
             <div class="col-sm-10">


### PR DESCRIPTION
This fixes #326. jupyter-shiny-proxy can look for shiny apps in alternative locations like ~/ShinyApps/. We need our instructors to be able to set this in targetPath via the form.

I tested this by building the docs locally and a JupyterHub link worked for me.