### PR TITLE
Add link to go back to root when an error is thrown

### DIFF
--- a/nbgitpuller/static/js/gitsyncview.js
+++ b/nbgitpuller/static/js/gitsyncview.js
@@ -59,10 +59,14 @@ export class GitSyncView{
     setProgressError(isError) {
         if (isError) {
             this.progress.classList.add('progress-bar-danger');
-            this.recovery.classList.remove('hidden');
         } else {
             this.progress.classList.remove('progress-bar-danger');
-            this.recovery.classList.add('hidden');
+        }
+    }
+
+    setRecoveryLink(isError) {
+        if (isError) {
+            this.recovery.classList.toggle('hidden', !visible);
         }
     }
 }

--- a/nbgitpuller/static/js/index.js
+++ b/nbgitpuller/static/js/index.js
@@ -46,6 +46,7 @@ gs.addHandler('error', function(data) {
     gsv.setProgressValue(100);
     gsv.setProgressText('Error: ' + data.message);
     gsv.setProgressError(true);
+    gsv.setRecoveryLink(true);
     gsv.setTerminalVisibility(true);
     if (data.output) {
         gsv.term.write(data.output);

--- a/nbgitpuller/templates/status.html
+++ b/nbgitpuller/templates/status.html
@@ -29,8 +29,10 @@ data-targetpath="{{ targetpath | urlencode }}"
     <div class="panel-body hidden" id="status-details-container">
             <div id="status-details"></div>
     </div>
-        <div id="recovery-link" class="hidden"><small>Go back to the <a href="{{ base_url }}">Jupyter root</a></small></div>
-    </div>
+</div>
+<div id="recovery-link" class="hidden">
+    <a class="btn btn-warning" href="{{ base_url }}" aria-label="Go to the Jupyter server without synchronizing content">Proceed to server without synchronizing</a>
+</div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Dear maintainers,

this pull request adds a link to the nbgitpuller page so the user can go back to the jupyter server root even when the pull goes wild for any reason.
It closes #278 (I hope).
Let me know if the users are redirected where they are supposed to.

Thanks for your attention. 