### PR TITLE
Fix link generator to use targetPath in urlpath construction

### DIFF
--- a/docs/_static/link_gen/link.js
+++ b/docs/_static/link_gen/link.js
@@ -166,6 +166,18 @@ function generateCloneDirectoryName(gitCloneUrl) {
     return lastPart.split(':').slice(-1)[0].replace(/(\.git|\.bundle)?/, '');
 }
 
+/**
+ * Return the effective clone directory to use in urlpath construction.
+ *
+ * If targetPath is provided (non-empty after trimming), use it as the directory
+ * where the repo will be cloned. Otherwise, fall back to the default name
+ * (typically derived from the repo URL).
+ */
+function getEffectiveCloneDirectory(targetPath, defaultName) {
+    var trimmedPath = targetPath ? targetPath.trim() : '';
+    return trimmedPath ? trimmedPath : defaultName;
+}
+
 function displayLink() {
     var form = document.getElementById('linkgenerator');
 
@@ -186,12 +198,14 @@ function displayLink() {
             var urlPath = document.getElementById('urlpath').value;
         } else {
             var repoName = generateCloneDirectoryName(repoUrl);
+            var cloneDirectory = getEffectiveCloneDirectory(targetPath, repoName);
             var urlPath;
             if (activeTab === "tab-auth-binder") {
                 var contentRepoName = new URL(contentRepoUrl).pathname.split('/').pop().replace(/\.git$/, '');
-                urlPath = apps[appName].generateUrlPath(contentRepoName + '/' + filePath);
+                var binderCloneDir = getEffectiveCloneDirectory(targetPath, contentRepoName);
+                urlPath = apps[appName].generateUrlPath(binderCloneDir + '/' + filePath);
             } else {
-                urlPath = apps[appName].generateUrlPath(repoName + '/' + filePath);
+                urlPath = apps[appName].generateUrlPath(cloneDirectory + '/' + filePath);
             }
         }
 


### PR DESCRIPTION
## Summary
- When a custom `targetPath` is specified in the link generator, the `urlpath` parameter was incorrectly using the repo-derived directory name instead of the specified `targetPath`
- Added `getEffectiveCloneDirectory()` helper function that returns `targetPath` when provided, falling back to the default name when empty
- Updated `displayLink()` to use this helper for both regular repos and binder auth tab scenarios

## Test plan
- [x] Tested locally with the link generator form
- [ ] Verify generated links use `targetPath` when specified
- [ ] Verify fallback to repo name when `targetPath` is empty